### PR TITLE
Complete reproducible PKP V7 full-cohort enrichment

### DIFF
--- a/docs/testing/ojs-journal-enrichment-qmd.tdd.md
+++ b/docs/testing/ojs-journal-enrichment-qmd.tdd.md
@@ -215,3 +215,59 @@ inconsistent, 19,054 unmatched, and 26,189 not attempted rows.
 The two repository-suite failures remain unchanged baseline debt: the owner
 README already lacked `## Question`, and the publication-compendium allowlist
 already excluded tracked literature notes before #101.
+
+## Issue #102: PKP–OpenAlex disagreement audit
+
+Source: [issue #102](https://github.com/YannJY02/InvisibleResearch/issues/102)
+and parent PRD [#98](https://github.com/YannJY02/InvisibleResearch/issues/98).
+No separate plan file was used. The user-approved resource adjustment remains
+authoritative: compact Parquet master and source/checkpoint catalogs are the
+fact layer; the audit CSV does not duplicate long source JSON.
+
+### User journey
+
+As a researcher, I can render the fixed V7 sample or complete 98,273-row
+cohort, inspect denominator-explicit identity and metadata disagreements, trace
+every aggregate to a compact audit row, and review three descriptive visuals
+and the fixed ten-row interactive table without changing the evidence or
+authority boundaries.
+
+### Task report
+
+| Stage | Commit | Command | Evidence |
+|---|---|---|---|
+| RED | `4c57e54` | `CROSSREF_MAILTO=... ./render_full.sh` | The existing QMD and #101 artifacts passed, then the shell contract exited 1 because `pkp-openalex-disagreement-audit.csv` did not exist. |
+| Sample GREEN | `ba66fb4` | `./render_sample.sh` | PASS: the ten fixed rows reconciled to six consistent, one partial-agreement, one conflicting-ID, one unmatched, and one no-valid-ISSN outcome; all report widgets rendered. |
+| Full GREEN | `ba66fb4` | `CROSSREF_MAILTO=... ./render_full.sh` | PASS: all 98,273 rows reconciled, all 1,031 OpenAlex batches and 169 Crossref pages were reused, zero API failures remained, and the complete report rendered. |
+| Independent CSV check | `ba66fb4` | Python `csv`/`Counter` reconciliation of the generated audit and summary | PASS: identity, five metadata dimensions, the source-status cross-tab, and 98,273 unique PKP identities matched independently. |
+| Syntax | `ba66fb4` | QMD code extraction plus R `parse()`; `sh -n`; `python3 -m py_compile analysis/ndjson_to_parquet.py` | PASS. |
+| Repository regression | `ba66fb4` | `uv run --with pytest --with pandas --with pyarrow pytest` | 25 passed; the same two pre-existing failures recorded for #101 remained. |
+| Dual review | `58c966a...ba66fb4` | Parallel Standards and Spec reviews | PASS on both axes with zero findings. |
+
+### Test specification
+
+| # | What is guaranteed | Test target | Type | Result |
+|---|---|---|---|---|
+| 1 | Every PKP row has exactly one of seven identity outcomes, including zero-count API error, and identity counts sum to the mode's cohort | Complete render, `contract-check`, and summary CSV | Classification | PASS |
+| 2 | Title, ISSN-set, OJS, DOAJ, and country comparisons each use the same 54,153-row identity-matched OpenAlex-journal denominator in the full run | Full render and summary reconciliation | Denominator | PASS |
+| 3 | DOAJ and country fields retain source-specific caveats; absent evidence is not converted into a negative assertion | Report prose, audit vocabulary, and metadata chart | Evidence boundary | PASS |
+| 4 | The compact audit preserves all 98,273 PKP identities, excludes long JSON and `admin_email`, and independently reconciles to the summary | Full audit CSV and independent CSV check | Auditability/privacy | PASS |
+| 5 | OpenAlex and Crossref states remain separate in a complete cross-tab whose counts sum to all 98,273 rows | Summary CSV, heatmap, and `contract-check` | Reconciliation | PASS |
+| 6 | The report includes count/percentage identity and metadata bar charts, a count/percentage heatmap, and the fixed searchable, filterable, paginated, horizontally scrollable ten-row table | Complete sample and full renders | End to end | PASS |
+| 7 | Input, master, catalogs, audit, and summary checksums; retrieval windows; cache/retry summaries; and runtime/package versions are recorded without API keys or process contact configuration | `run-metadata.json` and `contract-check` | Provenance/privacy | PASS |
+| 8 | Complete source objects remain in lossless checkpoints and resolve through compact catalogs instead of being repeated in the master or audit CSV | Full artifact contract and dual review | Resource/audit design | PASS |
+
+### Full-run evidence and known gaps
+
+The qualified full audit has 98,273 rows, 31 compact columns, and no long JSON.
+It records 53,615 consistent identities, 538 partial ISSN agreements, 221
+conflicting Source-ID cases, 133 non-journal Sources, 17,577 valid-ISSN
+unmatched rows, 26,189 rows without a valid ISSN, and zero API errors. The
+54-row summary records explicit denominators and occupies less than 5 KB; the
+audit CSV is approximately 40.4 MB.
+
+The agreed public seam remains the complete notebook render, so no separate
+line-coverage framework was added. The repository suite still has the same two
+baseline failures: this owner lacked `## Question` before #102, and the
+publication-compendium allowlist already excluded tracked literature notes.
+These unrelated governance changes remain outside #102.

--- a/docs/testing/ojs-journal-enrichment-qmd.tdd.md
+++ b/docs/testing/ojs-journal-enrichment-qmd.tdd.md
@@ -135,9 +135,9 @@ whose candidate IDs resolve to complete checkpointed Source responses.
 | Stage | Commit | Command | Evidence |
 |---|---|---|---|
 | RED | `640497e` | `./render_full.sh` | The existing notebook rendered only sample mode, then the full contract exited 1 because `full-v7/run-metadata.json` did not exist. |
-| Sample GREEN | GREEN commit | `./render_sample.sh` | PASS: the fixed ten-case OpenAlex/Crossref contract remained unchanged. |
-| Full GREEN | GREEN commit | `./render_full.sh` | PASS: 1,031 V7 checkpoints were reused, both Parquet files passed row/schema checks, and the report rendered. |
-| Python check | GREEN commit | `python3 -m py_compile analysis/ndjson_to_parquet.py` | PASS. |
+| Sample GREEN | `1da2cfe` | `./render_sample.sh` | PASS: the fixed ten-case OpenAlex/Crossref contract remained unchanged. |
+| Full GREEN | `1da2cfe` | `./render_full.sh` | PASS: 1,031 V7 checkpoints were reused, both Parquet files passed row/schema checks, and the report rendered. |
+| Python check | `1da2cfe` | `python3 -m py_compile analysis/ndjson_to_parquet.py` | PASS. |
 
 ### Test specification
 
@@ -147,7 +147,7 @@ whose candidate IDs resolve to complete checkpointed Source responses.
 | 2 | 103,017 valid ISSNs are split into 1,031 batches of at most 100 with 200-row cursor pages | Complete full render, `contract-check` | Integration | PASS |
 | 3 | Every complete checkpoint is tied to PKP V7 MD5 and its exact ISSN batch and is safely reusable | Complete full render after interrupted acquisition | Recovery | PASS |
 | 4 | API failures remain separate from unmatched rows and the qualified run has no unresolved failures | Full run metadata and `contract-check` | Contract | PASS |
-| 5 | The Parquet master has exactly 98,273 unique PKP rows and all candidate IDs reconcile to 54,520 unique Source IDs | Both Parquet artifacts and `contract-check` | Contract | PASS |
+| 5 | Reading the final Parquet files back yields exactly 98,273 unique PKP identities, reconciled status counts, 54,520 unique Source IDs, and no missing candidate/checkpoint references | PyArrow post-write validator and `contract-check` | Contract | PASS |
 | 6 | Complete Source responses remain in V7 checkpoints and the catalog indexes every Source ID to one checkpoint while recording all 37 observed top-level fields | Source catalog, schema manifest, and `contract-check` | Reconciliation | PASS |
 | 7 | Credentials and contact configuration are absent from metadata and generated columns | Complete full render, `contract-check` | Privacy | PASS |
 

--- a/docs/testing/ojs-journal-enrichment-qmd.tdd.md
+++ b/docs/testing/ojs-journal-enrichment-qmd.tdd.md
@@ -117,3 +117,50 @@ The repository failures are unchanged baseline debt:
 
 If the checkpoint commits are later squashed, preserve this RED/GREEN summary
 in the merge record.
+
+## Issue #100: resumable V7 OpenAlex full cohort
+
+Source: [issue #100](https://github.com/YannJY02/InvisibleResearch/issues/100)
+and parent PRD [#98](https://github.com/YannJY02/InvisibleResearch/issues/98).
+No separate plan file was used.
+
+### User journey
+
+As a researcher, I can explicitly start a resumable V7 OpenAlex run, preserve
+all PKP identities and exact-ISSN outcomes, and inspect a compact Parquet master
+whose candidate IDs resolve to complete checkpointed Source responses.
+
+### Task report
+
+| Stage | Commit | Command | Evidence |
+|---|---|---|---|
+| RED | `640497e` | `./render_full.sh` | The existing notebook rendered only sample mode, then the full contract exited 1 because `full-v7/run-metadata.json` did not exist. |
+| Sample GREEN | GREEN commit | `./render_sample.sh` | PASS: the fixed ten-case OpenAlex/Crossref contract remained unchanged. |
+| Full GREEN | GREEN commit | `./render_full.sh` | PASS: 1,031 V7 checkpoints were reused, both Parquet files passed row/schema checks, and the report rendered. |
+| Python check | GREEN commit | `python3 -m py_compile analysis/ndjson_to_parquet.py` | PASS. |
+
+### Test specification
+
+| # | What is guaranteed | Test target | Type | Result |
+|---|---|---|---|---|
+| 1 | Normal sample rendering cannot activate full mode; full mode is a separate command | `render_sample.sh`, `render_full.sh` | Contract | PASS |
+| 2 | 103,017 valid ISSNs are split into 1,031 batches of at most 100 with 200-row cursor pages | Complete full render, `contract-check` | Integration | PASS |
+| 3 | Every complete checkpoint is tied to PKP V7 MD5 and its exact ISSN batch and is safely reusable | Complete full render after interrupted acquisition | Recovery | PASS |
+| 4 | API failures remain separate from unmatched rows and the qualified run has no unresolved failures | Full run metadata and `contract-check` | Contract | PASS |
+| 5 | The Parquet master has exactly 98,273 unique PKP rows and all candidate IDs reconcile to 54,520 unique Source IDs | Both Parquet artifacts and `contract-check` | Contract | PASS |
+| 6 | Complete Source responses remain in V7 checkpoints and the catalog indexes every Source ID to one checkpoint while recording all 37 observed top-level fields | Source catalog, schema manifest, and `contract-check` | Reconciliation | PASS |
+| 7 | Credentials and contact configuration are absent from metadata and generated columns | Complete full render, `contract-check` | Privacy | PASS |
+
+### Full-run evidence and resource adjustment
+
+The qualified run produced a 98,273-row, 25-column master Parquet file
+(7.8 MB) and a 54,520-row Source-to-checkpoint catalog (293 KB). Statuses
+reconciled to 54,286 consistent, 221 inconsistent, 17,577 unmatched, and
+26,189 not attempted.
+
+An initial wide-CSV design was stopped after real execution showed excessive
+CPU, memory, and repeated JSON serialization. The approved Parquet adjustment
+keeps candidate IDs in the master and complete Source responses in their V7
+checkpoints instead of duplicating large JSON per PKP row. Temporary NDJSON
+staging files are removed only after PyArrow verifies Parquet row counts and
+schemas.

--- a/docs/testing/ojs-journal-enrichment-qmd.tdd.md
+++ b/docs/testing/ojs-journal-enrichment-qmd.tdd.md
@@ -164,3 +164,53 @@ keeps candidate IDs in the master and complete Source responses in their V7
 checkpoints instead of duplicating large JSON per PKP row. Temporary NDJSON
 staging files are removed only after PyArrow verifies Parquet row counts and
 schemas.
+
+## Issue #101: resumable Crossref journal directory
+
+Source: [issue #101](https://github.com/YannJY02/InvisibleResearch/issues/101)
+and parent PRD [#98](https://github.com/YannJY02/InvisibleResearch/issues/98).
+No separate plan file was used. The user-approved resource adjustment extends
+the compact Parquet master and checkpoint catalogs instead of restoring a wide
+CSV with repeated source JSON.
+
+### User journey
+
+As a researcher, I can provide a Crossref contact email only to the full-run
+process, resume a polite complete-directory retrieval, and inspect exact-ISSN
+Crossref outcomes whose candidate keys resolve to lossless page checkpoints.
+
+### Task report
+
+| Stage | Commit | Command | Evidence |
+|---|---|---|---|
+| RED | `f3684f9` | `CROSSREF_MAILTO=... ./render_full.sh` | The #100 notebook completed its full render, then the new contract exited 1 because the multisource master and Crossref catalog did not exist. |
+| Missing-contact check | `8a544c9` | `env -u CROSSREF_MAILTO ./render_full.sh` | Exit 1 in `packages-and-paths`: full mode required a contact email before retrieval. |
+| Sample GREEN | `8a544c9` | `./render_sample.sh` | PASS: the fixed ten-case sample rendered with no full-mode contact requirement. |
+| Full GREEN | `8a544c9` | `CROSSREF_MAILTO=... ./render_full.sh` | PASS: 169 Crossref pages and all 1,031 OpenAlex batches were reused, three Parquet files reconciled, and the HTML report rendered. |
+| Syntax | `8a544c9` | `python3 -m py_compile analysis/ndjson_to_parquet.py`; QMD code extraction plus R `parse()` | PASS. |
+| Repository regression | `8a544c9` | `uv run --with pytest --with pandas --with pyarrow pytest` | 25 passed; the same two baseline failures recorded for #99 remained. |
+
+### Test specification
+
+| # | What is guaranteed | Test target | Type | Result |
+|---|---|---|---|---|
+| 1 | Full mode rejects a missing or malformed process contact before source retrieval | `packages-and-paths` and missing-contact render | Privacy/preflight | PASS |
+| 2 | Crossref retrieval uses one sequential 1,000-row cursor stream with bounded retries, explicit failures, and a delay below the polite-pool limit | `perform_crossref_page`, `fetch_crossref_directory`, full metadata | Integration | PASS |
+| 3 | Each completed page is saved atomically and reused by page index, cursor, page size, status, and item count | Interrupted first run plus complete rerun | Recovery | PASS |
+| 4 | The short final page and the sum of all 169 page counts reconcile exactly to Crossref `total-results` 168,654 | Full render `contract-check` | Pagination | PASS |
+| 5 | Checksum-valid normalized ISSNs are matched locally; 137,473 unique ISSN sets remain in the catalog and distinct sets remain distinct candidates | Crossref catalog and full render `contract-check` | Identity | PASS |
+| 6 | The 98,273-row master preserves all PKP identities and separate Crossref consistent, inconsistent, unmatched, and not-attempted states | PyArrow validator and `contract-check` | Contract | PASS |
+| 7 | Candidate keys in the master resolve to a checkpoint file and record index while all 11 observed top-level fields remain in lossless checkpoints | Crossref catalog/schema and PyArrow validator | Reconciliation | PASS |
+| 8 | The configured contact does not appear in metadata, checkpoints, or any Parquet artifact | Full artifact byte scan and metadata contract | Privacy | PASS |
+
+### Coverage and known gaps
+
+The agreed executable seam is the complete QMD render, so no separate
+line-coverage framework was added. The qualified master has 98,273 rows and 30
+columns (9.3 MB); the Crossref catalog has 137,473 rows and three pointer
+columns (1.0 MB). Crossref statuses reconcile to 52,656 consistent, 374
+inconsistent, 19,054 unmatched, and 26,189 not attempted rows.
+
+The two repository-suite failures remain unchanged baseline debt: the owner
+README already lacked `## Question`, and the publication-compendium allowlist
+already excluded tracked literature notes before #101.

--- a/docs/testing/ojs-journal-enrichment-qmd.tdd.md
+++ b/docs/testing/ojs-journal-enrichment-qmd.tdd.md
@@ -187,6 +187,7 @@ Crossref outcomes whose candidate keys resolve to lossless page checkpoints.
 | Missing-contact check | `8a544c9` | `env -u CROSSREF_MAILTO ./render_full.sh` | Exit 1 in `packages-and-paths`: full mode required a contact email before retrieval. |
 | Sample GREEN | `8a544c9` | `./render_sample.sh` | PASS: the fixed ten-case sample rendered with no full-mode contact requirement. |
 | Full GREEN | `8a544c9` | `CROSSREF_MAILTO=... ./render_full.sh` | PASS: 169 Crossref pages and all 1,031 OpenAlex batches were reused, three Parquet files reconciled, and the HTML report rendered. |
+| Review fix | `e283b37` | `CROSSREF_MAILTO=... ./render_full.sh` | PASS: pagination stayed bounded by `total-results`; every Crossref pointer and checkpoint key reconciled in R; Python independently rebuilt and matched every master candidate set. |
 | Syntax | `8a544c9` | `python3 -m py_compile analysis/ndjson_to_parquet.py`; QMD code extraction plus R `parse()` | PASS. |
 | Repository regression | `8a544c9` | `uv run --with pytest --with pandas --with pyarrow pytest` | 25 passed; the same two baseline failures recorded for #99 remained. |
 

--- a/docs/testing/ojs-journal-enrichment-qmd.tdd.md
+++ b/docs/testing/ojs-journal-enrichment-qmd.tdd.md
@@ -147,7 +147,7 @@ whose candidate IDs resolve to complete checkpointed Source responses.
 | 2 | 103,017 valid ISSNs are split into 1,031 batches of at most 100 with 200-row cursor pages | Complete full render, `contract-check` | Integration | PASS |
 | 3 | Every complete checkpoint is tied to PKP V7 MD5 and its exact ISSN batch and is safely reusable | Complete full render after interrupted acquisition | Recovery | PASS |
 | 4 | API failures remain separate from unmatched rows and the qualified run has no unresolved failures | Full run metadata and `contract-check` | Contract | PASS |
-| 5 | Reading the final Parquet files back yields exactly 98,273 unique PKP identities, reconciled status counts, 54,520 unique Source IDs, and no missing candidate/checkpoint references | PyArrow post-write validator and `contract-check` | Contract | PASS |
+| 5 | Reading the final Parquet files back yields the exact pinned set of 98,273 PKP identities, reconciled status counts, 54,520 unique Source IDs, and the exact Source-to-checkpoint mapping | PyArrow post-write validator and `contract-check` | Contract | PASS |
 | 6 | Complete Source responses remain in V7 checkpoints and the catalog indexes every Source ID to one checkpoint while recording all 37 observed top-level fields | Source catalog, schema manifest, and `contract-check` | Reconciliation | PASS |
 | 7 | Credentials and contact configuration are absent from metadata and generated columns | Complete full render, `contract-check` | Privacy | PASS |
 

--- a/research/ojs-journal-metadata/README.md
+++ b/research/ojs-journal-metadata/README.md
@@ -20,24 +20,32 @@ under `research/ojs-journal-metadata/artifacts/ojs_journal_enrichment/`, which
 is ignored. This command always runs sample mode; it cannot start a full-cohort
 retrieval.
 
-Start the resumable V7 OpenAlex full-cohort run explicitly:
+Start the resumable V7 multisource full-cohort run explicitly:
 
 ```bash
 cd research/ojs-journal-metadata/analysis
-OPENALEX_API_KEY=... ./render_full.sh
+OPENALEX_API_KEY=... CROSSREF_MAILTO=you@example.org ./render_full.sh
 ```
 
 Full mode queries the 103,017 distinct valid ISSNs in deterministic groups of
 at most 100, follows cursor pagination, and checkpoints each completed batch
 under `ojs_journal_enrichment/full-v7/openalex-batches/`. A rerun reuses only
 complete checkpoints whose V7 checksum and exact batch contents match. It
-writes one OpenAlex-enriched row for each of the 98,273 PKP V7 rows in a
-Zstandard-compressed Parquet master. Candidate IDs join to a companion Parquet
-catalog that maps every unique OpenAlex Source ID to the complete V7 batch
-checkpoint retaining its response. The chunked NDJSON staging files are deleted
-after PyArrow verifies both Parquet row counts and schemas. Crossref
-full-cohort retrieval remains a separate follow-on. The V6 sections below
-document the earlier Python pipeline.
+also retrieves the complete Crossref journals directory in sequential
+1,000-record pages below the polite-pool limit. Each completed page is saved
+under `full-v7/crossref-pages/`, and the run stops only after the short final
+page and `total-results` reconcile. `CROSSREF_MAILTO` is sent as process
+configuration but is not stored in any generated artifact.
+
+The qualified 2026-07-29 run retrieved 168,654 Crossref journal records in 169
+pages. It writes one 30-column row for each of the 98,273 PKP V7 rows in the
+Zstandard-compressed `pkp-ojs-multisource-enriched.parquet` master. Candidate
+identities join to `openalex-sources.parquet` and `crossref-journals.parquet`;
+those compact catalogs point to checkpoints containing the complete source
+records rather than duplicating large JSON in the master. The chunked NDJSON
+staging files are deleted only after PyArrow verifies the master identities,
+status counts, catalog keys, checkpoint references, row counts, and schemas.
+The V6 sections below document the earlier Python pipeline.
 
 ## PKP input decision
 

--- a/research/ojs-journal-metadata/README.md
+++ b/research/ojs-journal-metadata/README.md
@@ -47,6 +47,23 @@ staging files are deleted only after PyArrow verifies the master identities,
 status counts, catalog keys, checkpoint references, row counts, and schemas.
 The V6 sections below document the earlier Python pipeline.
 
+Both commands also write
+`pkp-openalex-disagreement-audit.csv` and
+`pkp-openalex-disagreement-summary.csv` in their mode-specific artifact
+directory. The full audit has one compact, traceable row per PKP V7 identity;
+the summary records each category's eligible denominator and includes the
+OpenAlex-by-Crossref status cross-tabulation. The report shows counts and
+percentages, three descriptive charts, and the fixed ten-row V7 review table.
+It omits long JSON from the table only: complete source records remain in the
+ignored checkpoints and resolve through the compact Parquet catalogs.
+
+Delete generated reports, CSVs, Parquet files, or checkpoints when local
+storage is no longer needed; rerunning the same command recreates outputs and
+reuses any complete compatible checkpoints left in place. Title, ISSN, OJS,
+DOAJ, and country differences are source-specific metadata evidence, not proof
+that either source is wrong. PKP country is inferred, absent DOAJ evidence is
+not a negative assertion, and all results remain **Exploratory Analysis**.
+
 ## PKP input decision
 
 Use the original CSV behind `beacon.tab` in version 6.0 of [Details of

--- a/research/ojs-journal-metadata/README.md
+++ b/research/ojs-journal-metadata/README.md
@@ -3,7 +3,7 @@
 This owner investigates journal-level enrichment for PKP Beacon records. All
 work here remains **Exploratory Analysis**.
 
-## Reproduce the V7 Journal Enrichment Sample
+## Reproduce the V7 Journal Enrichment
 
 The current explanatory notebook pins PKP V7 Dataverse file `14084919` at MD5
 `3a4ad8ae1ebfcc2b991aaf55b2d82c92`. It downloads the file when absent, checks
@@ -15,10 +15,29 @@ cd research/ojs-journal-metadata/analysis
 OPENALEX_API_KEY=... ./render_sample.sh
 ```
 
-The input, source caches, enriched CSV, run metadata, and rendered report stay
+The input, source caches, enriched artifact, run metadata, and rendered report stay
 under `research/ojs-journal-metadata/artifacts/ojs_journal_enrichment/`, which
-is ignored. This command runs sample mode only; it does not start a full-cohort
-retrieval. The V6 sections below document the earlier Python pipeline.
+is ignored. This command always runs sample mode; it cannot start a full-cohort
+retrieval.
+
+Start the resumable V7 OpenAlex full-cohort run explicitly:
+
+```bash
+cd research/ojs-journal-metadata/analysis
+OPENALEX_API_KEY=... ./render_full.sh
+```
+
+Full mode queries the 103,017 distinct valid ISSNs in deterministic groups of
+at most 100, follows cursor pagination, and checkpoints each completed batch
+under `ojs_journal_enrichment/full-v7/openalex-batches/`. A rerun reuses only
+complete checkpoints whose V7 checksum and exact batch contents match. It
+writes one OpenAlex-enriched row for each of the 98,273 PKP V7 rows in a
+Zstandard-compressed Parquet master. Candidate IDs join to a companion Parquet
+catalog that maps every unique OpenAlex Source ID to the complete V7 batch
+checkpoint retaining its response. The chunked NDJSON staging files are deleted
+after PyArrow verifies both Parquet row counts and schemas. Crossref
+full-cohort retrieval remains a separate follow-on. The V6 sections below
+document the earlier Python pipeline.
 
 ## PKP input decision
 

--- a/research/ojs-journal-metadata/analysis/ndjson_to_parquet.py
+++ b/research/ojs-journal-metadata/analysis/ndjson_to_parquet.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Stream a fixed-schema NDJSON artifact into Parquet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.json as pajson
+import pyarrow.parquet as pq
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input", type=Path)
+    parser.add_argument("schema", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--expected-rows", type=int, required=True)
+    args = parser.parse_args()
+
+    columns = json.loads(args.schema.read_text())["columns"]
+    schema = pa.schema((column, pa.string()) for column in columns)
+    reader = pajson.open_json(
+        args.input,
+        read_options=pajson.ReadOptions(block_size=64 * 1024 * 1024),
+        parse_options=pajson.ParseOptions(explicit_schema=schema),
+    )
+
+    rows = 0
+    with pq.ParquetWriter(args.output, schema, compression="zstd") as writer:
+        for batch in reader:
+            writer.write_batch(batch)
+            rows += batch.num_rows
+
+    if rows != args.expected_rows:
+        args.output.unlink(missing_ok=True)
+        raise RuntimeError(f"Parquet row count mismatch: {rows}")
+
+    parquet = pq.ParquetFile(args.output)
+    if parquet.schema_arrow.names != columns:
+        args.output.unlink(missing_ok=True)
+        raise RuntimeError("Parquet schema does not match the declared columns")
+    print(
+        json.dumps(
+            {"rows": rows, "columns": len(columns), "pyarrow": pa.__version__}
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/research/ojs-journal-metadata/analysis/ndjson_to_parquet.py
+++ b/research/ojs-journal-metadata/analysis/ndjson_to_parquet.py
@@ -54,11 +54,21 @@ def validate(args: argparse.Namespace) -> None:
             "set_spec",
             "openalex_match_status",
             "openalex_candidate_ids",
+            "crossref_match_status",
+            "crossref_candidate_issn_sets",
         ],
     )
-    catalog = pq.read_table(
-        args.catalog,
+    openalex_catalog = pq.read_table(
+        args.openalex_catalog,
         columns=["openalex_source_id", "checkpoint_file"],
+    )
+    crossref_catalog = pq.read_table(
+        args.crossref_catalog,
+        columns=[
+            "crossref_candidate_issn_set",
+            "checkpoint_file",
+            "record_index",
+        ],
     )
 
     identities = set(
@@ -69,16 +79,42 @@ def validate(args: argparse.Namespace) -> None:
             strict=True,
         )
     )
-    statuses = Counter(master["openalex_match_status"].to_pylist())
-    source_ids = catalog["openalex_source_id"].to_pylist()
-    checkpoint_files = catalog["checkpoint_file"].to_pylist()
+    openalex_statuses = Counter(master["openalex_match_status"].to_pylist())
+    crossref_statuses = Counter(master["crossref_match_status"].to_pylist())
+    source_ids = openalex_catalog["openalex_source_id"].to_pylist()
+    source_checkpoint_files = openalex_catalog["checkpoint_file"].to_pylist()
     catalog_ids = set(source_ids)
-    actual_source_checkpoints = dict(zip(source_ids, checkpoint_files, strict=True))
-    candidate_ids = {
+    actual_source_checkpoints = dict(
+        zip(source_ids, source_checkpoint_files, strict=True)
+    )
+    openalex_candidate_ids = {
         candidate_id
         for cell in master["openalex_candidate_ids"].to_pylist()
         if cell
         for candidate_id in cell.split("|")
+    }
+    crossref_keys = crossref_catalog[
+        "crossref_candidate_issn_set"
+    ].to_pylist()
+    crossref_checkpoint_files = crossref_catalog[
+        "checkpoint_file"
+    ].to_pylist()
+    crossref_record_indices = crossref_catalog["record_index"].to_pylist()
+    crossref_catalog_ids = set(crossref_keys)
+    actual_crossref_checkpoints = {
+        candidate_key: f"{checkpoint_file}#{record_index}"
+        for candidate_key, checkpoint_file, record_index in zip(
+            crossref_keys,
+            crossref_checkpoint_files,
+            crossref_record_indices,
+            strict=True,
+        )
+    }
+    crossref_candidate_ids = {
+        candidate_id
+        for cell in master["crossref_candidate_issn_sets"].to_pylist()
+        if cell
+        for candidate_id in cell.split(";")
     }
     private_names = {"admin_email", "openalex_api_key", "crossref_mailto"}
     master_names = {name.casefold() for name in master.schema.names}
@@ -94,29 +130,56 @@ def validate(args: argparse.Namespace) -> None:
         raise RuntimeError("Master Parquet contains duplicate PKP identities")
     if identities != expected_identities:
         raise RuntimeError("Master Parquet PKP identities differ from pinned input")
-    if statuses != Counter(contract["status_counts"]):
-        raise RuntimeError("Master Parquet status counts do not reconcile")
+    if openalex_statuses != Counter(contract["status_counts"]["openalex"]):
+        raise RuntimeError("OpenAlex status counts do not reconcile")
+    if crossref_statuses != Counter(contract["status_counts"]["crossref"]):
+        raise RuntimeError("Crossref status counts do not reconcile")
     if len(source_ids) != len(catalog_ids):
         raise RuntimeError("Source catalog contains duplicate Source IDs")
-    if actual_source_checkpoints != contract["source_checkpoints"]:
+    if (
+        actual_source_checkpoints
+        != contract["openalex_source_checkpoints"]
+    ):
         raise RuntimeError("Source catalog ID-to-checkpoint mapping is incorrect")
-    if not candidate_ids <= catalog_ids:
+    if not openalex_candidate_ids <= catalog_ids:
         raise RuntimeError("Master candidate IDs are missing from the Source catalog")
+    if len(crossref_keys) != len(crossref_catalog_ids):
+        raise RuntimeError("Crossref catalog contains duplicate candidate keys")
+    if (
+        actual_crossref_checkpoints
+        != contract["crossref_source_checkpoints"]
+    ):
+        raise RuntimeError(
+            "Crossref catalog key-to-checkpoint mapping is incorrect"
+        )
+    if not crossref_candidate_ids <= crossref_catalog_ids:
+        raise RuntimeError(
+            "Master candidate keys are missing from the Crossref catalog"
+        )
     if private_names & master_names:
         raise RuntimeError("Private configuration appears in Parquet columns")
-    for checkpoint_file in checkpoint_files:
+    for checkpoint_file in source_checkpoint_files:
         if Path(checkpoint_file).name != checkpoint_file:
             raise RuntimeError("Unsafe checkpoint path in Source catalog")
-        if not (args.batch_dir / checkpoint_file).is_file():
+        if not (args.openalex_batch_dir / checkpoint_file).is_file():
             raise RuntimeError("Source catalog references a missing checkpoint")
+    for checkpoint_file in crossref_checkpoint_files:
+        if Path(checkpoint_file).name != checkpoint_file:
+            raise RuntimeError("Unsafe checkpoint path in Crossref catalog")
+        if not (args.crossref_page_dir / checkpoint_file).is_file():
+            raise RuntimeError(
+                "Crossref catalog references a missing checkpoint"
+            )
 
     print(
         json.dumps(
             {
                 "master_rows": master.num_rows,
                 "unique_identities": len(identities),
-                "catalog_rows": catalog.num_rows,
-                "candidate_ids": len(candidate_ids),
+                "openalex_catalog_rows": openalex_catalog.num_rows,
+                "openalex_candidate_ids": len(openalex_candidate_ids),
+                "crossref_catalog_rows": crossref_catalog.num_rows,
+                "crossref_candidate_ids": len(crossref_candidate_ids),
             }
         )
     )
@@ -134,8 +197,10 @@ def main() -> None:
 
     validate_parser = subparsers.add_parser("validate")
     validate_parser.add_argument("master", type=Path)
-    validate_parser.add_argument("catalog", type=Path)
-    validate_parser.add_argument("batch_dir", type=Path)
+    validate_parser.add_argument("openalex_catalog", type=Path)
+    validate_parser.add_argument("openalex_batch_dir", type=Path)
+    validate_parser.add_argument("crossref_catalog", type=Path)
+    validate_parser.add_argument("crossref_page_dir", type=Path)
     validate_parser.add_argument("input_csv", type=Path)
     validate_parser.add_argument("contract", type=Path)
     validate_parser.set_defaults(func=validate)

--- a/research/ojs-journal-metadata/analysis/ndjson_to_parquet.py
+++ b/research/ojs-journal-metadata/analysis/ndjson_to_parquet.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import argparse
-from collections import Counter
+from collections import Counter, defaultdict
 import csv
 import json
 from pathlib import Path
@@ -54,6 +54,7 @@ def validate(args: argparse.Namespace) -> None:
             "set_spec",
             "openalex_match_status",
             "openalex_candidate_ids",
+            "crossref_input_issns",
             "crossref_match_status",
             "crossref_candidate_issn_sets",
         ],
@@ -116,6 +117,10 @@ def validate(args: argparse.Namespace) -> None:
         if cell
         for candidate_id in cell.split(";")
     }
+    crossref_keys_by_issn: defaultdict[str, set[str]] = defaultdict(set)
+    for candidate_key in crossref_keys:
+        for issn in candidate_key.split("|"):
+            crossref_keys_by_issn[issn].add(candidate_key)
     private_names = {"admin_email", "openalex_api_key", "crossref_mailto"}
     master_names = {name.casefold() for name in master.schema.names}
     with args.input_csv.open(encoding="utf-8-sig", newline="") as handle:
@@ -156,6 +161,22 @@ def validate(args: argparse.Namespace) -> None:
         raise RuntimeError(
             "Master candidate keys are missing from the Crossref catalog"
         )
+    for input_cell, candidate_cell in zip(
+        master["crossref_input_issns"].to_pylist(),
+        master["crossref_candidate_issn_sets"].to_pylist(),
+        strict=True,
+    ):
+        expected_candidates = {
+            candidate_key
+            for issn in (input_cell or "").split("|")
+            if issn
+            for candidate_key in crossref_keys_by_issn[issn]
+        }
+        actual_candidates = set((candidate_cell or "").split(";")) - {""}
+        if actual_candidates != expected_candidates:
+            raise RuntimeError(
+                "Master Crossref candidates do not reconcile to the catalog"
+            )
     if private_names & master_names:
         raise RuntimeError("Private configuration appears in Parquet columns")
     for checkpoint_file in source_checkpoint_files:

--- a/research/ojs-journal-metadata/analysis/ndjson_to_parquet.py
+++ b/research/ojs-journal-metadata/analysis/ndjson_to_parquet.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from collections import Counter
+import csv
 import json
 from pathlib import Path
 
@@ -72,6 +73,7 @@ def validate(args: argparse.Namespace) -> None:
     source_ids = catalog["openalex_source_id"].to_pylist()
     checkpoint_files = catalog["checkpoint_file"].to_pylist()
     catalog_ids = set(source_ids)
+    actual_source_checkpoints = dict(zip(source_ids, checkpoint_files, strict=True))
     candidate_ids = {
         candidate_id
         for cell in master["openalex_candidate_ids"].to_pylist()
@@ -80,15 +82,24 @@ def validate(args: argparse.Namespace) -> None:
     }
     private_names = {"admin_email", "openalex_api_key", "crossref_mailto"}
     master_names = {name.casefold() for name in master.schema.names}
+    with args.input_csv.open(encoding="utf-8-sig", newline="") as handle:
+        expected_identities = {
+            (row["oai_url"], row["repository_name"], row["set_spec"])
+            for row in csv.DictReader(handle)
+        }
 
     if master.num_rows != contract["master_rows"]:
         raise RuntimeError("Master Parquet row count mismatch")
     if len(identities) != master.num_rows:
         raise RuntimeError("Master Parquet contains duplicate PKP identities")
+    if identities != expected_identities:
+        raise RuntimeError("Master Parquet PKP identities differ from pinned input")
     if statuses != Counter(contract["status_counts"]):
         raise RuntimeError("Master Parquet status counts do not reconcile")
     if len(source_ids) != len(catalog_ids):
         raise RuntimeError("Source catalog contains duplicate Source IDs")
+    if actual_source_checkpoints != contract["source_checkpoints"]:
+        raise RuntimeError("Source catalog ID-to-checkpoint mapping is incorrect")
     if not candidate_ids <= catalog_ids:
         raise RuntimeError("Master candidate IDs are missing from the Source catalog")
     if private_names & master_names:
@@ -125,6 +136,7 @@ def main() -> None:
     validate_parser.add_argument("master", type=Path)
     validate_parser.add_argument("catalog", type=Path)
     validate_parser.add_argument("batch_dir", type=Path)
+    validate_parser.add_argument("input_csv", type=Path)
     validate_parser.add_argument("contract", type=Path)
     validate_parser.set_defaults(func=validate)
 

--- a/research/ojs-journal-metadata/analysis/ndjson_to_parquet.py
+++ b/research/ojs-journal-metadata/analysis/ndjson_to_parquet.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 import json
 from pathlib import Path
 
@@ -12,14 +13,7 @@ import pyarrow.json as pajson
 import pyarrow.parquet as pq
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("input", type=Path)
-    parser.add_argument("schema", type=Path)
-    parser.add_argument("output", type=Path)
-    parser.add_argument("--expected-rows", type=int, required=True)
-    args = parser.parse_args()
-
+def convert(args: argparse.Namespace) -> None:
     columns = json.loads(args.schema.read_text())["columns"]
     schema = pa.schema((column, pa.string()) for column in columns)
     reader = pajson.open_json(
@@ -47,6 +41,95 @@ def main() -> None:
             {"rows": rows, "columns": len(columns), "pyarrow": pa.__version__}
         )
     )
+
+
+def validate(args: argparse.Namespace) -> None:
+    contract = json.loads(args.contract.read_text())
+    master = pq.read_table(
+        args.master,
+        columns=[
+            "oai_url",
+            "repository_name",
+            "set_spec",
+            "openalex_match_status",
+            "openalex_candidate_ids",
+        ],
+    )
+    catalog = pq.read_table(
+        args.catalog,
+        columns=["openalex_source_id", "checkpoint_file"],
+    )
+
+    identities = set(
+        zip(
+            master["oai_url"].to_pylist(),
+            master["repository_name"].to_pylist(),
+            master["set_spec"].to_pylist(),
+            strict=True,
+        )
+    )
+    statuses = Counter(master["openalex_match_status"].to_pylist())
+    source_ids = catalog["openalex_source_id"].to_pylist()
+    checkpoint_files = catalog["checkpoint_file"].to_pylist()
+    catalog_ids = set(source_ids)
+    candidate_ids = {
+        candidate_id
+        for cell in master["openalex_candidate_ids"].to_pylist()
+        if cell
+        for candidate_id in cell.split("|")
+    }
+    private_names = {"admin_email", "openalex_api_key", "crossref_mailto"}
+    master_names = {name.casefold() for name in master.schema.names}
+
+    if master.num_rows != contract["master_rows"]:
+        raise RuntimeError("Master Parquet row count mismatch")
+    if len(identities) != master.num_rows:
+        raise RuntimeError("Master Parquet contains duplicate PKP identities")
+    if statuses != Counter(contract["status_counts"]):
+        raise RuntimeError("Master Parquet status counts do not reconcile")
+    if len(source_ids) != len(catalog_ids):
+        raise RuntimeError("Source catalog contains duplicate Source IDs")
+    if not candidate_ids <= catalog_ids:
+        raise RuntimeError("Master candidate IDs are missing from the Source catalog")
+    if private_names & master_names:
+        raise RuntimeError("Private configuration appears in Parquet columns")
+    for checkpoint_file in checkpoint_files:
+        if Path(checkpoint_file).name != checkpoint_file:
+            raise RuntimeError("Unsafe checkpoint path in Source catalog")
+        if not (args.batch_dir / checkpoint_file).is_file():
+            raise RuntimeError("Source catalog references a missing checkpoint")
+
+    print(
+        json.dumps(
+            {
+                "master_rows": master.num_rows,
+                "unique_identities": len(identities),
+                "catalog_rows": catalog.num_rows,
+                "candidate_ids": len(candidate_ids),
+            }
+        )
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    convert_parser = subparsers.add_parser("convert")
+    convert_parser.add_argument("input", type=Path)
+    convert_parser.add_argument("schema", type=Path)
+    convert_parser.add_argument("output", type=Path)
+    convert_parser.add_argument("--expected-rows", type=int, required=True)
+    convert_parser.set_defaults(func=convert)
+
+    validate_parser = subparsers.add_parser("validate")
+    validate_parser.add_argument("master", type=Path)
+    validate_parser.add_argument("catalog", type=Path)
+    validate_parser.add_argument("batch_dir", type=Path)
+    validate_parser.add_argument("contract", type=Path)
+    validate_parser.set_defaults(func=validate)
+
+    args = parser.parse_args()
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/research/ojs-journal-metadata/analysis/ojs_journal_enrichment.qmd
+++ b/research/ojs-journal-metadata/analysis/ojs_journal_enrichment.qmd
@@ -899,7 +899,17 @@ if (run_mode == "sample") {
   jsonlite::write_json(
     list(
       master_rows = nrow(base_result),
-      status_counts = as.list(output_status_counts)
+      status_counts = as.list(output_status_counts),
+      source_checkpoints = as.list(set_names(
+        vapply(
+          map_chr(openalex_sources, "id"),
+          get,
+          character(1),
+          envir = checkpoint_by_source,
+          inherits = FALSE
+        ),
+        map_chr(openalex_sources, "id")
+      ))
     ),
     parquet_validation_path,
     auto_unbox = TRUE,
@@ -914,6 +924,7 @@ if (run_mode == "sample") {
       shQuote(output_path),
       shQuote(source_output_path),
       shQuote(openalex_batch_dir),
+      shQuote(input_path),
       shQuote(parquet_validation_path)
     ),
     stdout = TRUE,

--- a/research/ojs-journal-metadata/analysis/ojs_journal_enrichment.qmd
+++ b/research/ojs-journal-metadata/analysis/ojs_journal_enrichment.qmd
@@ -477,6 +477,13 @@ fetch_crossref_directory <- function() {
     page_summaries[[length(page_summaries) + 1L]] <- checkpoint[
       setdiff(names(checkpoint), c("cursor", "next_cursor", "items"))
     ]
+    retrieved_rows <- sum(map_int(page_summaries, "item_count"))
+    if (retrieved_rows > total_results) {
+      stop(
+        "Crossref pagination exceeded total-results.",
+        call. = FALSE
+      )
+    }
     if (isTRUE(checkpoint$pagination_complete)) break
     if (
       is.null(checkpoint$next_cursor) ||
@@ -692,6 +699,60 @@ crossref_catalog_from_pages <- function(page_files) {
     rows = bind_rows(catalog_pages),
     source_fields = sort(source_fields)
   )
+}
+
+validate_crossref_catalog_pointers <- function(catalog, page_files) {
+  catalog_rows_by_page <- split(
+    seq_len(nrow(catalog)),
+    catalog$checkpoint_file
+  )
+  checkpoint_keys <- character()
+
+  for (page_file in page_files) {
+    checkpoint <- readRDS(file.path(crossref_page_dir, page_file))
+    page_keys <- vapply(
+      checkpoint$items,
+      crossref_key,
+      character(1)
+    )
+    checkpoint_keys <- union(
+      checkpoint_keys,
+      page_keys[nzchar(page_keys)]
+    )
+
+    catalog_rows <- catalog_rows_by_page[[page_file]]
+    if (is.null(catalog_rows)) next
+    record_indices <- as.integer(catalog$record_index[catalog_rows])
+    if (
+      anyNA(record_indices) ||
+        any(record_indices < 1L | record_indices > length(page_keys))
+    ) {
+      stop(
+        "Crossref catalog contains an invalid record index.",
+        call. = FALSE
+      )
+    }
+    if (!identical(
+      unname(catalog$crossref_candidate_issn_set[catalog_rows]),
+      unname(page_keys[record_indices])
+    )) {
+      stop(
+        "Crossref catalog pointer does not resolve to its ISSN set.",
+        call. = FALSE
+      )
+    }
+  }
+
+  if (!setequal(
+    catalog$crossref_candidate_issn_set,
+    checkpoint_keys
+  )) {
+    stop(
+      "Crossref catalog does not cover every checkpoint candidate.",
+      call. = FALSE
+    )
+  }
+  TRUE
 }
 
 index_crossref_catalog <- function(catalog) {
@@ -1044,6 +1105,10 @@ if (run_mode == "sample") {
     crossref_directory$page_files
   )
   crossref_catalog <- crossref_catalog_contract$rows
+  crossref_catalog_valid <- validate_crossref_catalog_pointers(
+    crossref_catalog,
+    crossref_directory$page_files
+  )
   crossref_index <- index_crossref_catalog(crossref_catalog)
   crossref_matches <- map(
     input_issns,
@@ -1422,6 +1487,7 @@ stopifnot(
     "index_candidates_by_issn",
     "candidates_for_issns",
     "crossref_catalog_from_pages",
+    "validate_crossref_catalog_pointers",
     "index_crossref_catalog",
     "match_crossref_catalog",
     "expand_candidate_fields",
@@ -1566,6 +1632,7 @@ if (run_mode == "sample") {
     parquet_contract$columns == length(output_columns),
     source_parquet_contract$rows == length(openalex_sources),
     crossref_parquet_contract$rows == nrow(crossref_catalog),
+    isTRUE(crossref_catalog_valid),
     parquet_validation$master_rows == 98273L,
     parquet_validation$unique_identities == 98273L,
     parquet_validation$openalex_catalog_rows == length(openalex_sources),

--- a/research/ojs-journal-metadata/analysis/ojs_journal_enrichment.qmd
+++ b/research/ojs-journal-metadata/analysis/ojs_journal_enrichment.qmd
@@ -19,12 +19,15 @@ This chunk installs only missing CRAN packages, loads them, downloads the pinned
 #| label: packages-and-paths
 
 required_packages <- c(
+  "countrycode",
   "dplyr",
+  "ggplot2",
   "httr2",
   "jsonlite",
   "knitr",
   "purrr",
   "readr",
+  "reactable",
   "rmarkdown",
   "tibble"
 )
@@ -36,6 +39,7 @@ if (length(missing_packages)) {
 }
 
 library(dplyr)
+library(ggplot2)
 library(httr2)
 library(purrr)
 library(readr)
@@ -84,6 +88,11 @@ output_path <- file.path(
   }
 )
 metadata_path <- file.path(run_dir, "run-metadata.json")
+audit_path <- file.path(run_dir, "pkp-openalex-disagreement-audit.csv")
+audit_summary_path <- file.path(
+  run_dir,
+  "pkp-openalex-disagreement-summary.csv"
+)
 staging_path <- file.path(run_dir, "pkp-ojs-multisource-enriched.ndjson")
 parquet_schema_path <- file.path(run_dir, "parquet-schema.json")
 source_output_path <- file.path(run_dir, "openalex-sources.parquet")
@@ -895,6 +904,46 @@ expand_candidate_fields <- function(match, prefix) {
   )
   as_tibble(cells, .name_repair = "check_unique")
 }
+
+normalize_title <- function(value) {
+  if (length(value) != 1L || is.na(value) || !nzchar(trimws(value))) {
+    return(NA_character_)
+  }
+  transliterated <- iconv(value, from = "", to = "ASCII//TRANSLIT")
+  if (is.na(transliterated)) transliterated <- value
+  gsub("[^[:alnum:]]", "", tolower(transliterated))
+}
+
+source_value <- function(source, field) {
+  value <- source[[field]]
+  if (is.null(value) || !length(value) || is.na(value[[1]])) {
+    return(NA_character_)
+  }
+  as.character(value[[1]])
+}
+
+comparison_state <- function(left, right) {
+  if (is.na(left) || is.na(right)) return("not_observed")
+  if (identical(left, right)) "same" else "different"
+}
+
+category_summary <- function(
+  values,
+  categories,
+  dimension,
+  denominator_name
+) {
+  counts <- table(factor(values, levels = categories))
+  denominator <- length(values)
+  tibble(
+    dimension = dimension,
+    category = names(counts),
+    denominator_name = denominator_name,
+    denominator = denominator,
+    count = as.integer(counts),
+    percent = round(100 * count / denominator, 3)
+  )
+}
 ```
 
 ### Enrichment orchestration
@@ -1336,6 +1385,272 @@ if (run_mode == "sample") {
   review_result <- build_master_chunk(sample_positions)
 }
 
+selected_openalex_sources <- map(openalex_matches, \(match) {
+  if (length(match$candidates) == 1L) match$candidates[[1]] else NULL
+})
+openalex_source_types <- map_chr(
+  selected_openalex_sources,
+  source_value,
+  field = "type"
+)
+openalex_source_issn_sets <- map_chr(selected_openalex_sources, \(source) {
+  paste(sort(source_issns(source)), collapse = "|")
+})
+input_issn_sets <- map_chr(input_issns, \(issns) {
+  paste(sort(issns), collapse = "|")
+})
+matched_issn_sets <- map_chr(openalex_matches, \(match) {
+  paste(sort(match$matched_issns), collapse = "|")
+})
+
+identity_outcome <- case_when(
+  base_result$identifier_status != "valid" ~ "no_valid_issn",
+  base_result$openalex_match_status == "api_error" ~ "api_error",
+  base_result$openalex_candidate_count == 0L ~ "valid_issn_unmatched",
+  base_result$openalex_candidate_count > 1L ~ "conflicting_source_ids",
+  is.na(openalex_source_types) |
+    tolower(openalex_source_types) != "journal" ~ "non_journal_source",
+  input_issn_sets != matched_issn_sets ~ "partial_issn_agreement",
+  TRUE ~ "consistent"
+)
+identity_matched <- identity_outcome %in% c(
+  "consistent",
+  "partial_issn_agreement"
+)
+
+pkp_normalized_titles <- map_chr(ojs_rows$context_name, normalize_title)
+openalex_normalized_titles <- map(selected_openalex_sources, \(source) {
+  titles <- c(
+    source_value(source, "display_name"),
+    unlist(source$alternate_titles, use.names = FALSE)
+  )
+  normalized <- unique(na.omit(map_chr(titles, normalize_title)))
+  normalized[nzchar(normalized)]
+})
+title_comparison <- map2_chr(
+  pkp_normalized_titles,
+  openalex_normalized_titles,
+  \(pkp_title, openalex_titles) {
+    if (!length(openalex_titles) || is.na(pkp_title)) return("not_observed")
+    if (pkp_title %in% openalex_titles) "same" else "different"
+  }
+)
+title_comparison[!identity_matched] <- "not_observed"
+
+issn_set_comparison <- map2_chr(
+  input_issn_sets,
+  openalex_source_issn_sets,
+  comparison_state
+)
+issn_set_comparison[!identity_matched] <- "not_observed"
+
+openalex_ojs_evidence <- map_chr(
+  selected_openalex_sources,
+  source_value,
+  field = "is_ojs"
+)
+ojs_evidence_comparison <- case_when(
+  !identity_matched | is.na(openalex_ojs_evidence) ~ "not_observed",
+  openalex_ojs_evidence == "TRUE" ~ "same",
+  TRUE ~ "different"
+)
+
+pkp_doaj_evidence <- !is.na(ojs_rows$best_doaj_url) &
+  nzchar(trimws(ojs_rows$best_doaj_url))
+openalex_doaj_evidence <- map_chr(
+  selected_openalex_sources,
+  source_value,
+  field = "is_in_doaj"
+)
+doaj_evidence_comparison <- case_when(
+  !identity_matched | is.na(openalex_doaj_evidence) ~ "not_observed",
+  pkp_doaj_evidence & openalex_doaj_evidence == "TRUE" ~ "both_observed",
+  pkp_doaj_evidence ~ "pkp_only",
+  openalex_doaj_evidence == "TRUE" ~ "openalex_only",
+  TRUE ~ "neither_observed"
+)
+
+pkp_country_code <- suppressWarnings(countrycode::countrycode(
+  ojs_rows$country,
+  origin = "country.name",
+  destination = "iso2c"
+))
+openalex_country_code <- toupper(map_chr(
+  selected_openalex_sources,
+  source_value,
+  field = "country_code"
+))
+country_evidence_comparison <- map2_chr(
+  pkp_country_code,
+  openalex_country_code,
+  comparison_state
+)
+country_evidence_comparison[!identity_matched] <- "not_observed"
+
+audit_base <- if (run_mode == "sample") result else base_result
+audit <- audit_base |>
+  transmute(
+    oai_url,
+    repository_name,
+    set_spec,
+    context_name,
+    issn,
+    identifier_status,
+    openalex_input_issns,
+    openalex_matched_issns,
+    openalex_match_status,
+    openalex_candidate_count,
+    openalex_candidate_ids,
+    crossref_match_status,
+    crossref_candidate_count = if ("crossref_candidate_count" %in% names(
+      audit_base
+    )) {
+      crossref_candidate_count
+    } else {
+      map_int(crossref_matches, \(match) length(match$candidate_ids))
+    },
+    crossref_candidate_issn_sets,
+    identity_outcome,
+    openalex_source_type = openalex_source_types,
+    openalex_display_name = map_chr(
+      selected_openalex_sources,
+      source_value,
+      field = "display_name"
+    ),
+    pkp_normalized_title = pkp_normalized_titles,
+    openalex_normalized_titles = map_chr(
+      openalex_normalized_titles,
+      paste,
+      collapse = "|"
+    ),
+    title_comparison,
+    pkp_issn_set = input_issn_sets,
+    openalex_issn_set = openalex_source_issn_sets,
+    issn_set_comparison,
+    ojs_evidence_comparison,
+    pkp_doaj_evidence,
+    openalex_doaj_evidence,
+    doaj_evidence_comparison,
+    pkp_country = country,
+    pkp_country_code,
+    openalex_country_code,
+    country_evidence_comparison
+  )
+
+identity_categories <- c(
+  "consistent",
+  "partial_issn_agreement",
+  "conflicting_source_ids",
+  "non_journal_source",
+  "valid_issn_unmatched",
+  "no_valid_issn",
+  "api_error"
+)
+comparison_categories <- c("same", "different", "not_observed")
+matched_denominator <- sum(identity_matched)
+status_categories <- c(
+  "consistent",
+  "inconsistent",
+  "unmatched",
+  "not_attempted",
+  "api_error"
+)
+source_status_counts <- as_tibble(as.data.frame(table(
+  openalex = factor(
+    audit$openalex_match_status,
+    levels = status_categories
+  ),
+  crossref = factor(
+    audit$crossref_match_status,
+    levels = status_categories
+  )
+))) |>
+  transmute(
+    dimension = "source_status_crosstab",
+    category = paste0("openalex=", openalex, "|crossref=", crossref),
+    denominator_name = "all_pkp_v7_rows",
+    denominator = nrow(audit),
+    count = as.integer(Freq),
+    percent = round(100 * count / denominator, 3)
+  )
+metadata_disagreement_counts <- c(
+  normalized_title = sum(title_comparison == "different"),
+  issn_set = sum(issn_set_comparison == "different"),
+  ojs_evidence = sum(ojs_evidence_comparison == "different"),
+  doaj_evidence = sum(doaj_evidence_comparison %in% c(
+    "pkp_only",
+    "openalex_only"
+  )),
+  country_evidence = sum(country_evidence_comparison == "different")
+)
+metadata_disagreement_summary <- tibble(
+  dimension = "metadata_disagreement",
+  category = names(metadata_disagreement_counts),
+  denominator_name = "identity_matched_openalex_journals",
+  denominator = matched_denominator,
+  count = as.integer(metadata_disagreement_counts),
+  percent = round(100 * count / denominator, 3)
+)
+audit_summary <- bind_rows(
+  category_summary(
+    identity_outcome,
+    identity_categories,
+    "identity_outcome",
+    "all_pkp_v7_rows"
+  ),
+  category_summary(
+    title_comparison[identity_matched],
+    comparison_categories,
+    "normalized_title",
+    "identity_matched_openalex_journals"
+  ),
+  category_summary(
+    issn_set_comparison[identity_matched],
+    comparison_categories,
+    "issn_set",
+    "identity_matched_openalex_journals"
+  ),
+  category_summary(
+    ojs_evidence_comparison[identity_matched],
+    comparison_categories,
+    "ojs_evidence",
+    "identity_matched_openalex_journals"
+  ),
+  category_summary(
+    doaj_evidence_comparison[identity_matched],
+    c(
+      "both_observed",
+      "pkp_only",
+      "openalex_only",
+      "neither_observed",
+      "not_observed"
+    ),
+    "doaj_evidence",
+    "identity_matched_openalex_journals"
+  ),
+  category_summary(
+    country_evidence_comparison[identity_matched],
+    comparison_categories,
+    "country_evidence",
+    "identity_matched_openalex_journals"
+  ),
+  metadata_disagreement_summary,
+  source_status_counts
+)
+write_csv(audit, audit_path, na = "")
+write_csv(audit_summary, audit_summary_path, na = "")
+
+openalex_retrieval_times <- if (run_mode == "full") {
+  unlist(map(batch_results, \(batch) map_chr(batch$pages, "retrieved_at")))
+} else {
+  character()
+}
+crossref_retrieval_times <- if (run_mode == "full") {
+  map_chr(crossref_directory$pages, "retrieved_at")
+} else {
+  character()
+}
+
 run_metadata <- list(
   producer = "analysis/ojs_journal_enrichment.qmd",
   run_mode = run_mode,
@@ -1359,6 +1674,16 @@ run_metadata <- list(
       openalex = as.list(openalex_status_counts),
       crossref = as.list(crossref_status_counts)
     )
+  ),
+  disagreement_audit = list(
+    file = basename(audit_path),
+    md5 = unname(tools::md5sum(audit_path)),
+    rows = nrow(audit),
+    columns = ncol(audit),
+    summary_file = basename(audit_summary_path),
+    summary_md5 = unname(tools::md5sum(audit_summary_path)),
+    summary_rows = nrow(audit_summary),
+    identity_matched_rows = matched_denominator
   ),
   source_catalog = if (run_mode == "full") {
     list(
@@ -1384,6 +1709,20 @@ run_metadata <- list(
     NULL
   },
   parquet_validation = if (run_mode == "full") parquet_validation else NULL,
+  retrieval = if (run_mode == "full") {
+    list(
+      openalex = list(
+        first = min(openalex_retrieval_times),
+        last = max(openalex_retrieval_times)
+      ),
+      crossref = list(
+        first = min(crossref_retrieval_times),
+        last = max(crossref_retrieval_times)
+      )
+    )
+  } else {
+    NULL
+  },
   openalex = if (run_mode == "full") {
     list(
       batch_size = 100L,
@@ -1461,6 +1800,21 @@ These checks confirm that every input row appears in the master, every returned 
 
 metadata_text <- paste(readLines(metadata_path, warn = FALSE), collapse = "\n")
 artifact_root <- normalizePath(artifact_dir)
+metadata_dimensions <- c(
+  "normalized_title",
+  "issn_set",
+  "ojs_evidence",
+  "doaj_evidence",
+  "country_evidence"
+)
+metadata_reconciliation <- audit_summary |>
+  filter(dimension %in% metadata_dimensions) |>
+  group_by(dimension) |>
+  summarise(
+    denominator = unique(denominator),
+    count = sum(count),
+    .groups = "drop"
+  )
 
 stopifnot(
   identical(pkp_version, 7L),
@@ -1475,7 +1829,11 @@ stopifnot(
   startsWith(normalizePath(input_path), artifact_root),
   startsWith(normalizePath(output_path), artifact_root),
   startsWith(normalizePath(metadata_path), artifact_root),
+  startsWith(normalizePath(audit_path), artifact_root),
+  startsWith(normalizePath(audit_summary_path), artifact_root),
   file.exists(metadata_path),
+  file.exists(audit_path),
+  file.exists(audit_summary_path),
   !grepl("OPENALEX_API_KEY|CROSSREF_MAILTO", metadata_text),
   all(nzchar(unlist(run_metadata$runtime))),
   all(vapply(c(
@@ -1491,7 +1849,11 @@ stopifnot(
     "index_crossref_catalog",
     "match_crossref_catalog",
     "expand_candidate_fields",
-    "serialize_json"
+    "serialize_json",
+    "normalize_title",
+    "source_value",
+    "comparison_state",
+    "category_summary"
   ), exists, logical(1), mode = "function")),
   exists("fetch_openalex_sources", mode = "function"),
   exists("fetch_crossref_journal", mode = "function"),
@@ -1516,7 +1878,27 @@ stopifnot(
   )),
   sum(unlist(run_metadata$output$status_counts$openalex)) == output_rows,
   sum(unlist(run_metadata$output$status_counts$crossref)) == output_rows,
-  !"admin_email" %in% output_columns
+  !"admin_email" %in% output_columns,
+  nrow(audit) == output_rows,
+  identical(audit$identity_outcome, identity_outcome),
+  setequal(
+    audit_summary$category[audit_summary$dimension == "identity_outcome"],
+    identity_categories
+  ),
+  sum(audit_summary$count[
+    audit_summary$dimension == "identity_outcome"
+  ]) == output_rows,
+  nrow(metadata_reconciliation) == length(metadata_dimensions),
+  all(metadata_reconciliation$denominator == matched_denominator),
+  all(metadata_reconciliation$count == matched_denominator),
+  sum(audit_summary$count[
+    audit_summary$dimension == "source_status_crosstab"
+  ]) == output_rows,
+  all(audit_summary$denominator[
+    audit_summary$dimension == "source_status_crosstab"
+  ] == output_rows),
+  !"admin_email" %in% names(audit),
+  all(is.finite(audit_summary$percent))
 )
 
 if (run_mode == "sample") {
@@ -1542,6 +1924,18 @@ if (run_mode == "sample") {
     candidate_field_names,
     prefix = "crossref"
   )))
+  expected_identity_outcome <- c(
+    "consistent",
+    "consistent",
+    "valid_issn_unmatched",
+    "consistent",
+    "consistent",
+    "consistent",
+    "consistent",
+    "partial_issn_agreement",
+    "no_valid_issn",
+    "conflicting_source_ids"
+  )
   stopifnot(
     identical(row_identity(ojs_rows), sample_identity),
     sum(result$identifier_status == "missing") == 1L,
@@ -1569,6 +1963,7 @@ if (run_mode == "sample") {
       map_chr(crossref_matches, \(match) serialize_json(match$candidates))
     ),
     identical(result$openalex_match_status, expected_openalex_status),
+    identical(identity_outcome, expected_identity_outcome),
     result$openalex_matched_issns[
       result$context_name == "Jami Scientific Research Quarterly Journal"
     ] == "2710-4990",
@@ -1592,6 +1987,17 @@ if (run_mode == "sample") {
     run_metadata$openalex$completed_batches == length(token_batches),
     run_metadata$openalex$failed_batches == 0L,
     !any(base_result$openalex_match_status == "api_error"),
+    !any(identity_outcome == "api_error"),
+    all(nzchar(unlist(run_metadata$retrieval))),
+    run_metadata$disagreement_audit$rows == 98273L,
+    identical(
+      unname(tools::md5sum(audit_path)),
+      run_metadata$disagreement_audit$md5
+    ),
+    identical(
+      unname(tools::md5sum(audit_summary_path)),
+      run_metadata$disagreement_audit$summary_md5
+    ),
     identical(crossref_directory$status, "complete"),
     identical(
       match_crossref_catalog(
@@ -1657,20 +2063,127 @@ if (run_mode == "sample") {
 }
 ```
 
-## Complete merged dataframe
+## Identity outcomes
 
-This table displays all columns for the ten purposive review rows. In full mode the complete 98,273-row result stays in the master Parquet file while the report remains inspectable.
+These categories describe exact-ISSN identity evidence. They do not establish
+which source is correct and do not explain why a difference exists.
 
 ```{r}
-#| label: complete-sample-dataframe
+#| label: identity-outcome-chart
+#| fig-width: 9
+#| fig-height: 5
 
-review_result |>
-  knitr::kable(format = "html")
+audit_summary |>
+  filter(dimension == "identity_outcome") |>
+  ggplot(aes(x = reorder(category, count), y = count)) +
+  geom_col() +
+  geom_text(
+    aes(label = sprintf("%s (%.2f%%)", count, percent)),
+    hjust = -0.05,
+    size = 3
+  ) +
+  coord_flip(clip = "off") +
+  scale_y_continuous(expand = expansion(mult = c(0, 0.18))) +
+  labs(x = NULL, y = "PKP V7 rows") +
+  theme_minimal()
+```
+
+## Metadata comparisons
+
+Metadata comparisons are limited to PKP rows with one exact-ISSN OpenAlex
+journal identity. Title comparison uses normalized PKP titles against both the
+OpenAlex display name and alternate titles. PKP country is inferred metadata,
+not authoritative publisher location. PKP and OpenAlex DOAJ fields are
+source-specific positive evidence; absence is not proof that a journal is not
+in DOAJ.
+
+```{r}
+#| label: metadata-disagreement-chart
+#| fig-width: 9
+#| fig-height: 4.5
+
+metadata_disagreement_summary |>
+  ggplot(aes(x = reorder(category, count), y = count)) +
+  geom_col() +
+  geom_text(
+    aes(label = sprintf("%s (%.2f%%)", count, percent)),
+    hjust = -0.05,
+    size = 3
+  ) +
+  coord_flip(clip = "off") +
+  scale_y_continuous(expand = expansion(mult = c(0, 0.18))) +
+  labs(x = NULL, y = "Identity-matched OpenAlex journals") +
+  theme_minimal()
+```
+
+## OpenAlex and Crossref match states
+
+Source absence remains a source-specific `unmatched` or `not_attempted` state;
+it is not collapsed into a generic metadata failure.
+
+```{r}
+#| label: source-status-heatmap
+#| fig-width: 9
+#| fig-height: 6
+
+audit_summary |>
+  filter(dimension == "source_status_crosstab") |>
+  mutate(
+    openalex = sub("\\|.*$", "", sub("^openalex=", "", category)),
+    crossref = sub("^.*\\|crossref=", "", category)
+  ) |>
+  ggplot(aes(x = openalex, y = crossref, fill = count)) +
+  geom_tile() +
+  geom_text(aes(label = sprintf("%s\n%.2f%%", count, percent)), size = 3) +
+  labs(x = "OpenAlex match state", y = "Crossref match state", fill = "Rows") +
+  theme_minimal()
+```
+
+## Purposive ten-row review
+
+This searchable, filterable table uses the fixed V7 sample in its deliberate
+display order. It includes every compact master field and omits only columns
+whose values are long JSON; complete OpenAlex and Crossref objects remain
+available through the source catalogs and checkpoint pointers.
+
+```{r}
+#| label: interactive-sample-dataframe
+
+is_long_json_column <- function(column) {
+  values <- na.omit(as.character(column))
+  any(
+    nchar(values) > 200L &
+      grepl("^[[:space:]]*[\\[{]", values)
+  )
+}
+long_json_columns <- names(review_result)[
+  endsWith(names(review_result), "__json") |
+    map_lgl(review_result, is_long_json_column)
+]
+review_table <- review_result[
+  setdiff(names(review_result), long_json_columns)
+]
+
+htmltools::div(
+  style = "overflow-x: auto;",
+  reactable::reactable(
+    review_table,
+    searchable = TRUE,
+    filterable = TRUE,
+    pagination = TRUE,
+    defaultPageSize = 10,
+    showPageSizeOptions = TRUE,
+    resizable = TRUE,
+    compact = TRUE,
+    fullWidth = FALSE
+  )
+)
 ```
 
 ## Complete merged column list
 
-This table lists every column in the master artifact so collaborators can review its structure.
+This table lists every column in the compact master artifact. Long source
+objects live in checkpoints instead of being duplicated across PKP rows.
 
 ```{r}
 #| label: complete-column-list

--- a/research/ojs-journal-metadata/analysis/ojs_journal_enrichment.qmd
+++ b/research/ojs-journal-metadata/analysis/ojs_journal_enrichment.qmd
@@ -7,9 +7,9 @@ execute:
   message: false
 ---
 
-This notebook adds current OpenAlex Source data to PKP OJS rows from the pinned V7 release by exact ISSN. Sample mode is the default and also checks Crossref against ten deliberately selected rows. Full mode must be started with `render_full.sh`; it checkpoints V7 OpenAlex responses and preserves all 98,273 PKP rows.
+This notebook adds current OpenAlex Source and Crossref journal data to PKP OJS rows from the pinned V7 release by exact ISSN. Sample mode is the default. Full mode must be started with `render_full.sh`; it checkpoints both source directories and preserves all 98,273 PKP rows in a compact Parquet master.
 
-Set `OPENALEX_API_KEY` in the environment or the repository-root `.env` file before rendering. A normal render and `render_sample.sh` always use sample mode.
+Set `OPENALEX_API_KEY` in the environment or the repository-root `.env` file before rendering. Full mode also requires `CROSSREF_MAILTO` as process configuration. A normal render and `render_sample.sh` always use sample mode.
 
 ## Packages and paths
 
@@ -51,6 +51,16 @@ if (!nzchar(Sys.getenv("OPENALEX_API_KEY")) && file.exists(project_env_path)) {
 if (!nzchar(Sys.getenv("OPENALEX_API_KEY"))) {
   stop("Set OPENALEX_API_KEY before running this notebook.", call. = FALSE)
 }
+crossref_mailto <- Sys.getenv("CROSSREF_MAILTO")
+if (
+  run_mode == "full" &&
+    !grepl("^[^@[:space:]]+@[^@[:space:]]+$", crossref_mailto)
+) {
+  stop(
+    "Set CROSSREF_MAILTO to a contact email before a full render.",
+    call. = FALSE
+  )
+}
 
 pkp_version <- 7L
 pkp_url <- paste0(
@@ -68,26 +78,31 @@ run_dir <- file.path(
 output_path <- file.path(
   run_dir,
   if (run_mode == "full") {
-    "pkp-ojs-openalex-enriched.parquet"
+    "pkp-ojs-multisource-enriched.parquet"
   } else {
     "pkp-ojs-multisource-enriched.csv"
   }
 )
 metadata_path <- file.path(run_dir, "run-metadata.json")
-staging_path <- file.path(run_dir, "pkp-ojs-openalex-enriched.ndjson")
+staging_path <- file.path(run_dir, "pkp-ojs-multisource-enriched.ndjson")
 parquet_schema_path <- file.path(run_dir, "parquet-schema.json")
 source_output_path <- file.path(run_dir, "openalex-sources.parquet")
 source_staging_path <- file.path(run_dir, "openalex-sources.ndjson")
 source_schema_path <- file.path(run_dir, "openalex-sources-schema.json")
+crossref_output_path <- file.path(run_dir, "crossref-journals.parquet")
+crossref_staging_path <- file.path(run_dir, "crossref-journals.ndjson")
+crossref_schema_path <- file.path(run_dir, "crossref-journals-schema.json")
 parquet_validation_path <- file.path(run_dir, "parquet-validation.json")
 openalex_cache_path <- file.path(run_dir, "openalex-sources.rds")
 crossref_cache_path <- file.path(run_dir, "crossref-journals.rds")
 openalex_batch_dir <- file.path(run_dir, "openalex-batches")
+crossref_page_dir <- file.path(run_dir, "crossref-pages")
 
 dir.create(input_dir, recursive = TRUE, showWarnings = FALSE)
 dir.create(run_dir, recursive = TRUE, showWarnings = FALSE)
 if (run_mode == "full") {
   dir.create(openalex_batch_dir, recursive = TRUE, showWarnings = FALSE)
+  dir.create(crossref_page_dir, recursive = TRUE, showWarnings = FALSE)
 }
 
 curl <- Sys.which("curl")
@@ -138,6 +153,7 @@ ISSNs may contain spaces, punctuation, or more than one value. This chunk conver
 #| label: issn-preparation
 
 normalize_issn <- function(value) {
+  if (length(value) != 1L || is.na(value)) return(NA_character_)
   compact <- gsub("[^0-9X]", "", toupper(trimws(as.character(value))))
   if (!grepl("^[0-9]{7}[0-9X]$", compact)) return(NA_character_)
 
@@ -172,7 +188,7 @@ source_issns <- function(source) {
 
 ## Source retrieval
 
-The sample sends all valid ISSNs to OpenAlex in one request. Full mode splits the 103,017 valid ISSNs into deterministic groups of at most 100, requests the maximum page size, follows every cursor, and atomically checkpoints each completed V7 batch. A failed batch remains an API-error state and is retried on the next run.
+The sample sends all valid ISSNs to OpenAlex in one request. Full mode splits the 103,017 valid ISSNs into deterministic groups of at most 100, requests the maximum page size, follows every cursor, and atomically checkpoints each completed V7 batch. It also downloads the complete Crossref journals directory in sequential 1,000-record cursor pages, sleeping between requests and checkpointing each page. Failed responses remain explicit and are retried on the next run.
 
 Sample mode asks Crossref about each ISSN separately and waits between requests. A Crossref `404` means that no journal record was found.
 
@@ -310,7 +326,7 @@ save_rds_atomic <- function(value, path) {
   saveRDS(value, temporary)
   if (!file.rename(temporary, path)) {
     unlink(temporary)
-    stop("Could not checkpoint OpenAlex batch.", call. = FALSE)
+    stop("Could not save checkpoint atomically.", call. = FALSE)
   }
   invisible(path)
 }
@@ -326,6 +342,174 @@ fetch_crossref_journal <- function(issn) {
     req_perform()
   if (resp_status(response) == 404L) return(NULL)
   resp_body_json(response, simplifyVector = FALSE)$message
+}
+
+perform_crossref_page <- function(
+  cursor,
+  mailto,
+  max_attempts = 4L
+) {
+  stopifnot(nzchar(cursor), nzchar(mailto))
+
+  for (attempt in seq_len(max_attempts)) {
+    response <- tryCatch(
+      request("https://api.crossref.org/journals") |>
+        req_url_query(
+          rows = 1000,
+          cursor = cursor,
+          mailto = mailto
+        ) |>
+        req_user_agent(
+          "InvisibleResearch journal enrichment; https://github.com/YannJY02/InvisibleResearch"
+        ) |>
+        req_timeout(seconds = 60) |>
+        req_error(is_error = \(response) FALSE) |>
+        req_perform(),
+      error = identity
+    )
+
+    if (!inherits(response, "condition")) {
+      status <- resp_status(response)
+      if (status < 400L) {
+        body <- tryCatch(
+          resp_body_json(response, simplifyVector = FALSE)$message,
+          error = identity
+        )
+        if (
+          !inherits(body, "condition") &&
+            is.list(body) &&
+            is.list(body$items) &&
+            length(body[["total-results"]]) == 1L
+        ) {
+          return(list(ok = TRUE, attempts = attempt, body = body))
+        }
+        failure <- "parse_error"
+        retryable <- TRUE
+      } else {
+        failure <- paste0("http_", status)
+        retryable <- status %in% c(
+          403L, 408L, 429L, 500L, 502L, 503L, 504L
+        )
+      }
+    } else {
+      failure <- "transport_error"
+      retryable <- TRUE
+    }
+
+    if (!retryable || attempt == max_attempts) {
+      return(list(
+        ok = FALSE,
+        attempts = attempt,
+        failure = failure
+      ))
+    }
+    Sys.sleep(min(2^(attempt - 1L), 8))
+  }
+}
+
+fetch_crossref_directory <- function() {
+  cursor <- "*"
+  page_index <- 1L
+  page_summaries <- list()
+  page_files <- character()
+  total_results <- NULL
+
+  repeat {
+    page_file <- sprintf("page-%04d.rds", page_index)
+    checkpoint_path <- file.path(crossref_page_dir, page_file)
+    checkpoint <- if (file.exists(checkpoint_path)) {
+      tryCatch(readRDS(checkpoint_path), error = \(error) NULL)
+    } else {
+      NULL
+    }
+    reusable <- !is.null(checkpoint) &&
+      identical(checkpoint$page_index, page_index) &&
+      identical(checkpoint$cursor, cursor) &&
+      identical(checkpoint$rows_per_page, 1000L) &&
+      identical(checkpoint$status, "complete") &&
+      identical(checkpoint$item_count, length(checkpoint$items))
+
+    if (reusable) {
+      checkpoint$reused <- TRUE
+    } else {
+      page <- perform_crossref_page(cursor, crossref_mailto)
+      checkpoint <- list(
+        status = if (page$ok) "complete" else "api_error",
+        page_index = page_index,
+        cursor = cursor,
+        rows_per_page = 1000L,
+        total_results = if (page$ok) {
+          as.integer(page$body[["total-results"]])
+        } else {
+          NA_integer_
+        },
+        next_cursor = if (page$ok) page$body[["next-cursor"]] else NULL,
+        items = if (page$ok) page$body$items else list(),
+        item_count = if (page$ok) length(page$body$items) else 0L,
+        attempts = page$attempts,
+        failure = if (page$ok) NULL else page$failure,
+        pagination_complete = page$ok && length(page$body$items) < 1000L,
+        retrieved_at = format(Sys.time(), tz = "UTC", usetz = TRUE),
+        reused = FALSE
+      )
+      save_rds_atomic(checkpoint, checkpoint_path)
+    }
+
+    if (checkpoint$status != "complete") {
+      stop(
+        paste0(
+          "Crossref page ", page_index,
+          " failed explicitly: ", checkpoint$failure
+        ),
+        call. = FALSE
+      )
+    }
+    if (is.null(total_results)) {
+      total_results <- checkpoint$total_results
+    } else if (!identical(total_results, checkpoint$total_results)) {
+      stop(
+        "Crossref total-results changed during cursor pagination.",
+        call. = FALSE
+      )
+    }
+
+    page_files <- c(page_files, page_file)
+    page_summaries[[length(page_summaries) + 1L]] <- checkpoint[
+      setdiff(names(checkpoint), c("cursor", "next_cursor", "items"))
+    ]
+    if (isTRUE(checkpoint$pagination_complete)) break
+    if (
+      is.null(checkpoint$next_cursor) ||
+        !nzchar(checkpoint$next_cursor)
+    ) {
+      stop(
+        "Crossref returned a full page without a next cursor.",
+        call. = FALSE
+      )
+    }
+
+    cursor <- checkpoint$next_cursor
+    page_index <- page_index + 1L
+    Sys.sleep(0.2)
+  }
+
+  directory_rows <- sum(map_int(page_summaries, "item_count"))
+  if (directory_rows != total_results) {
+    stop(
+      paste0(
+        "Crossref directory row count mismatch: ",
+        directory_rows, " != ", total_results
+      ),
+      call. = FALSE
+    )
+  }
+  list(
+    status = "complete",
+    rows_per_page = 1000L,
+    directory_rows = directory_rows,
+    pages = page_summaries,
+    page_files = page_files
+  )
 }
 
 ```
@@ -448,7 +632,7 @@ ojs_rows <- if (run_mode == "full") {
 
 ## Multi-source enrichment
 
-For each PKP row, the sample looks for OpenAlex and Crossref records with the same ISSN. If the same source record appears more than once, it is counted once. Sample mode expands returned fields for review. Full mode keeps candidate IDs in the one-row-per-PKP master and indexes each unique Source ID to its complete V7 checkpoint response in a companion Parquet catalog.
+For each PKP row, the notebook looks for OpenAlex and Crossref records with the same checksum-valid normalized ISSN. If the same source identity appears more than once, it is counted once. Sample mode expands returned fields for review. Full mode keeps compact candidate identities in the one-row-per-PKP master and indexes both sources to complete checkpoint responses in companion Parquet catalogs.
 
 ### Sample matching helpers
 
@@ -469,6 +653,80 @@ classify_status <- function(input_issns, candidate_ids) {
 crossref_key <- function(journal) {
   issns <- vapply(journal$ISSN, normalize_issn, character(1))
   paste(sort(unique(issns[!is.na(issns)])), collapse = "|")
+}
+
+crossref_catalog_from_pages <- function(page_files) {
+  seen_keys <- new.env(hash = TRUE, parent = emptyenv())
+  catalog_pages <- vector("list", length(page_files))
+  source_fields <- character()
+
+  for (page_position in seq_along(page_files)) {
+    page_file <- page_files[[page_position]]
+    checkpoint <- readRDS(file.path(crossref_page_dir, page_file))
+    if (checkpoint$status != "complete") {
+      stop("Crossref catalog encountered an incomplete page.", call. = FALSE)
+    }
+    source_fields <- union(
+      source_fields,
+      unlist(map(checkpoint$items, names), use.names = FALSE)
+    )
+    page_rows <- imap(checkpoint$items, \(journal, record_index) {
+      candidate_key <- crossref_key(journal)
+      if (
+        !nzchar(candidate_key) ||
+          exists(candidate_key, seen_keys, inherits = FALSE)
+      ) {
+        return(NULL)
+      }
+      assign(candidate_key, TRUE, seen_keys)
+      tibble(
+        crossref_candidate_issn_set = candidate_key,
+        checkpoint_file = page_file,
+        record_index = as.character(record_index)
+      )
+    })
+    catalog_pages[[page_position]] <- bind_rows(compact(page_rows))
+  }
+
+  list(
+    rows = bind_rows(catalog_pages),
+    source_fields = sort(source_fields)
+  )
+}
+
+index_crossref_catalog <- function(catalog) {
+  index <- new.env(hash = TRUE, parent = emptyenv())
+  for (candidate_key in catalog$crossref_candidate_issn_set) {
+    for (issn in strsplit(candidate_key, "|", fixed = TRUE)[[1]]) {
+      candidate_keys <- if (exists(issn, index, inherits = FALSE)) {
+        get(issn, index, inherits = FALSE)
+      } else {
+        character()
+      }
+      assign(issn, c(candidate_keys, candidate_key), index)
+    }
+  }
+  index
+}
+
+match_crossref_catalog <- function(input_issns, index) {
+  candidate_keys <- as.character(unique(unlist(map(input_issns, \(issn) {
+    if (exists(issn, index, inherits = FALSE)) {
+      get(issn, index, inherits = FALSE)
+    } else {
+      character()
+    }
+  }))))
+  candidate_issns <- unique(unlist(strsplit(
+    candidate_keys,
+    "|",
+    fixed = TRUE
+  )))
+  list(
+    status = classify_status(input_issns, candidate_keys),
+    matched_issns = intersect(input_issns, candidate_issns),
+    candidate_ids = candidate_keys
+  )
 }
 
 deduplicate_candidates <- function(candidates, identity) {
@@ -580,7 +838,7 @@ expand_candidate_fields <- function(match, prefix) {
 
 ### Enrichment orchestration
 
-Both modes use the same exact-ISSN matcher. Full mode indexes candidates by normalized ISSN so matching 98,273 rows does not repeatedly scan the complete Source response set. Candidate IDs connect the compact master to the Source catalog and lossless V7 checkpoints, so inconsistent identities remain complete without duplicating large Source JSON.
+Both modes use the same exact-ISSN rule. Full mode indexes candidates by normalized ISSN so matching 98,273 rows does not repeatedly scan either complete response set. Candidate identities connect the compact master to source catalogs and lossless checkpoints, so inconsistent identities remain complete without duplicating large JSON.
 
 ```{r}
 #| label: enrichment
@@ -686,7 +944,7 @@ openalex_matches <- map(input_issns, \(issns) {
   if (any(issns %in% failed_issns)) match$status <- "api_error"
   match
 })
-output_status_counts <- table(map_chr(openalex_matches, "status"))
+openalex_status_counts <- table(map_chr(openalex_matches, "status"))
 
 base_result <- ojs_rows |>
   mutate(
@@ -756,6 +1014,7 @@ if (run_mode == "sample") {
       crossref_key
     )
   })
+  crossref_status_counts <- table(map_chr(crossref_matches, "status"))
   crossref_data <- map_dfr(
     crossref_matches,
     expand_candidate_fields,
@@ -780,11 +1039,40 @@ if (run_mode == "sample") {
   output_columns <- names(result)
   review_result <- result
 } else {
-  crossref_cache_hit <- FALSE
-  crossref_matches <- list()
-  source_fields <- sort(unique(unlist(map(openalex_sources, names))))
+  crossref_directory <- fetch_crossref_directory()
+  crossref_catalog_contract <- crossref_catalog_from_pages(
+    crossref_directory$page_files
+  )
+  crossref_catalog <- crossref_catalog_contract$rows
+  crossref_index <- index_crossref_catalog(crossref_catalog)
+  crossref_matches <- map(
+    input_issns,
+    match_crossref_catalog,
+    index = crossref_index
+  )
+  crossref_status_counts <- table(map_chr(crossref_matches, "status"))
+  base_result <- base_result |>
+    mutate(
+      crossref_input_issns = map_chr(input_issns, paste, collapse = "|"),
+      crossref_matched_issns = map_chr(
+        crossref_matches,
+        \(match) paste(match$matched_issns, collapse = "|")
+      ),
+      crossref_match_status = map_chr(crossref_matches, "status"),
+      crossref_candidate_count = map_int(
+        crossref_matches,
+        \(match) length(match$candidate_ids)
+      ),
+      crossref_candidate_issn_sets = map_chr(
+        crossref_matches,
+        \(match) paste(match$candidate_ids, collapse = ";")
+      )
+    )
+
+  openalex_fields <- sort(unique(unlist(map(openalex_sources, names))))
   output_columns <- names(base_result)
   source_output_columns <- c("openalex_source_id", "checkpoint_file")
+  crossref_output_columns <- names(crossref_catalog)
   checkpoint_by_source <- new.env(hash = TRUE, parent = emptyenv())
   for (batch in batch_results) {
     checkpoint_file <- sprintf("batch-%04d.rds", batch$batch_index)
@@ -814,6 +1102,15 @@ if (run_mode == "sample") {
       )),
       stringsAsFactors = FALSE
     )
+  }
+
+  build_crossref_chunk <- function(indices) {
+    chunk <- as.data.frame(
+      crossref_catalog[indices, ],
+      stringsAsFactors = FALSE
+    )
+    chunk[] <- lapply(chunk, as.character)
+    chunk[crossref_output_columns]
   }
 
   write_ndjson_chunks <- function(path, rows, builder) {
@@ -882,7 +1179,7 @@ if (run_mode == "sample") {
   jsonlite::write_json(
     list(
       columns = source_output_columns,
-      source_fields = source_fields
+      source_fields = openalex_fields
     ),
     source_schema_path,
     auto_unbox = TRUE,
@@ -896,11 +1193,36 @@ if (run_mode == "sample") {
   )
   unlink(source_staging_path)
 
+  write_ndjson_chunks(
+    crossref_staging_path,
+    nrow(crossref_catalog),
+    build_crossref_chunk
+  )
+  jsonlite::write_json(
+    list(
+      columns = crossref_output_columns,
+      source_fields = crossref_catalog_contract$source_fields
+    ),
+    crossref_schema_path,
+    auto_unbox = TRUE,
+    pretty = TRUE
+  )
+  crossref_parquet_contract <- convert_to_parquet(
+    crossref_staging_path,
+    crossref_schema_path,
+    crossref_output_path,
+    nrow(crossref_catalog)
+  )
+  unlink(crossref_staging_path)
+
   jsonlite::write_json(
     list(
       master_rows = nrow(base_result),
-      status_counts = as.list(output_status_counts),
-      source_checkpoints = as.list(set_names(
+      status_counts = list(
+        openalex = as.list(openalex_status_counts),
+        crossref = as.list(crossref_status_counts)
+      ),
+      openalex_source_checkpoints = as.list(set_names(
         vapply(
           map_chr(openalex_sources, "id"),
           get,
@@ -909,6 +1231,14 @@ if (run_mode == "sample") {
           inherits = FALSE
         ),
         map_chr(openalex_sources, "id")
+      )),
+      crossref_source_checkpoints = as.list(set_names(
+        paste(
+          crossref_catalog$checkpoint_file,
+          crossref_catalog$record_index,
+          sep = "#"
+        ),
+        crossref_catalog$crossref_candidate_issn_set
       ))
     ),
     parquet_validation_path,
@@ -924,6 +1254,8 @@ if (run_mode == "sample") {
       shQuote(output_path),
       shQuote(source_output_path),
       shQuote(openalex_batch_dir),
+      shQuote(crossref_output_path),
+      shQuote(crossref_page_dir),
       shQuote(input_path),
       shQuote(parquet_validation_path)
     ),
@@ -958,7 +1290,10 @@ run_metadata <- list(
     format = if (run_mode == "full") "parquet" else "csv",
     rows = output_rows,
     columns = length(output_columns),
-    status_counts = as.list(output_status_counts)
+    status_counts = list(
+      openalex = as.list(openalex_status_counts),
+      crossref = as.list(crossref_status_counts)
+    )
   ),
   source_catalog = if (run_mode == "full") {
     list(
@@ -966,7 +1301,19 @@ run_metadata <- list(
       md5 = unname(tools::md5sum(source_output_path)),
       rows = source_parquet_contract$rows,
       columns = source_parquet_contract$columns,
-      retained_top_level_fields = source_fields
+      retained_top_level_fields = openalex_fields
+    )
+  } else {
+    NULL
+  },
+  crossref_catalog = if (run_mode == "full") {
+    list(
+      file = basename(crossref_output_path),
+      md5 = unname(tools::md5sum(crossref_output_path)),
+      rows = crossref_parquet_contract$rows,
+      columns = crossref_parquet_contract$columns,
+      retained_top_level_fields =
+        crossref_catalog_contract$source_fields
     )
   } else {
     NULL
@@ -989,13 +1336,29 @@ run_metadata <- list(
       reused = openalex_cache_hit
     )
   },
-  crossref = if (run_mode == "sample") {
+  crossref = if (run_mode == "full") {
+    list(
+      status = crossref_directory$status,
+      rows_per_page = crossref_directory$rows_per_page,
+      directory_rows = crossref_directory$directory_rows,
+      pages = length(crossref_directory$pages),
+      completed_pages = sum(
+        map_chr(crossref_directory$pages, "status") == "complete"
+      ),
+      reused_pages = sum(map_lgl(
+        crossref_directory$pages,
+        "reused"
+      )),
+      attempts = sum(map_int(crossref_directory$pages, "attempts")),
+      failed_pages = sum(
+        map_chr(crossref_directory$pages, "status") != "complete"
+      )
+    )
+  } else {
     list(
       cache_file = basename(crossref_cache_path),
       reused = crossref_cache_hit
     )
-  } else {
-    list(status = "not_attempted")
   },
   runtime = list(
     r = R.version.string,
@@ -1026,7 +1389,7 @@ jsonlite::write_json(
 
 ## Checks
 
-These checks confirm that every input row appears in the master, every returned top-level API field remains in the lossless Source catalog, candidate IDs reconcile, credentials stay private, and full-mode pagination completed without unresolved API failures.
+These checks confirm that every input row appears in the master, every returned top-level API field remains in the lossless source checkpoints, both catalogs reconcile, credentials stay private, and full-mode pagination completed without unresolved API failures.
 
 ```{r}
 #| label: contract-check
@@ -1036,6 +1399,7 @@ artifact_root <- normalizePath(artifact_dir)
 
 stopifnot(
   identical(pkp_version, 7L),
+  is.na(normalize_issn(NULL)),
   identical(unname(tools::md5sum(input_path)), pkp_md5),
   nrow(raw_input) == 98273L,
   identical(names(raw_input), expected_schema),
@@ -1057,11 +1421,15 @@ stopifnot(
     "deduplicate_candidates",
     "index_candidates_by_issn",
     "candidates_for_issns",
+    "crossref_catalog_from_pages",
+    "index_crossref_catalog",
+    "match_crossref_catalog",
     "expand_candidate_fields",
     "serialize_json"
   ), exists, logical(1), mode = "function")),
   exists("fetch_openalex_sources", mode = "function"),
   exists("fetch_crossref_journal", mode = "function"),
+  exists("fetch_crossref_directory", mode = "function"),
   output_rows == nrow(ojs_rows),
   file.exists(output_path),
   all(c(
@@ -1080,7 +1448,8 @@ stopifnot(
     "not_attempted",
     "api_error"
   )),
-  sum(unlist(run_metadata$output$status_counts)) == output_rows,
+  sum(unlist(run_metadata$output$status_counts$openalex)) == output_rows,
+  sum(unlist(run_metadata$output$status_counts$crossref)) == output_rows,
   !"admin_email" %in% output_columns
 )
 
@@ -1157,20 +1526,66 @@ if (run_mode == "sample") {
     run_metadata$openalex$completed_batches == length(token_batches),
     run_metadata$openalex$failed_batches == 0L,
     !any(base_result$openalex_match_status == "api_error"),
+    identical(crossref_directory$status, "complete"),
+    identical(
+      match_crossref_catalog(
+        character(),
+        new.env(hash = TRUE, parent = emptyenv())
+      )$status,
+      "not_attempted"
+    ),
+    identical(crossref_directory$rows_per_page, 1000L),
+    crossref_directory$directory_rows ==
+      sum(map_int(crossref_directory$pages, "item_count")),
+    all(map_int(
+      crossref_directory$pages[-length(crossref_directory$pages)],
+      "item_count"
+    ) == 1000L),
+    last(crossref_directory$pages)$item_count < 1000L,
+    all(map_chr(crossref_directory$pages, "status") == "complete"),
+    run_metadata$crossref$completed_pages ==
+      length(crossref_directory$pages),
+    run_metadata$crossref$failed_pages == 0L,
+    all(c(
+      "crossref_match_status",
+      "crossref_candidate_count",
+      "crossref_candidate_issn_sets"
+    ) %in% output_columns),
+    identical(
+      base_result$crossref_candidate_count,
+      map_int(crossref_matches, \(match) length(match$candidate_ids))
+    ),
+    all(base_result$crossref_match_status %in% c(
+      "consistent",
+      "inconsistent",
+      "unmatched",
+      "not_attempted"
+    )),
+    !any(base_result$crossref_match_status == "api_error"),
     identical(run_metadata$output$format, "parquet"),
     parquet_contract$columns == length(output_columns),
     source_parquet_contract$rows == length(openalex_sources),
+    crossref_parquet_contract$rows == nrow(crossref_catalog),
     parquet_validation$master_rows == 98273L,
     parquet_validation$unique_identities == 98273L,
-    parquet_validation$catalog_rows == length(openalex_sources),
+    parquet_validation$openalex_catalog_rows == length(openalex_sources),
+    parquet_validation$crossref_catalog_rows == nrow(crossref_catalog),
     !anyDuplicated(map_chr(openalex_sources, "id")),
+    !anyDuplicated(crossref_catalog$crossref_candidate_issn_set),
     all(unique(unlist(map(openalex_matches, "candidate_ids"))) %in%
       map_chr(openalex_sources, "id")),
+    all(unique(unlist(map(crossref_matches, "candidate_ids"))) %in%
+      crossref_catalog$crossref_candidate_issn_set),
     length(run_metadata$source_catalog$retained_top_level_fields) ==
-      length(source_fields),
+      length(openalex_fields),
+    length(
+      run_metadata$crossref_catalog$retained_top_level_fields
+    ) == length(crossref_catalog_contract$source_fields),
     file.exists(source_output_path),
+    file.exists(crossref_output_path),
     !file.exists(staging_path),
-    !file.exists(source_staging_path)
+    !file.exists(source_staging_path),
+    !file.exists(crossref_staging_path)
   )
 }
 ```

--- a/research/ojs-journal-metadata/analysis/ojs_journal_enrichment.qmd
+++ b/research/ojs-journal-metadata/analysis/ojs_journal_enrichment.qmd
@@ -79,6 +79,7 @@ parquet_schema_path <- file.path(run_dir, "parquet-schema.json")
 source_output_path <- file.path(run_dir, "openalex-sources.parquet")
 source_staging_path <- file.path(run_dir, "openalex-sources.ndjson")
 source_schema_path <- file.path(run_dir, "openalex-sources-schema.json")
+parquet_validation_path <- file.path(run_dir, "parquet-validation.json")
 openalex_cache_path <- file.path(run_dir, "openalex-sources.rds")
 crossref_cache_path <- file.path(run_dir, "crossref-journals.rds")
 openalex_batch_dir <- file.path(run_dir, "openalex-batches")
@@ -685,6 +686,7 @@ openalex_matches <- map(input_issns, \(issns) {
   if (any(issns %in% failed_issns)) match$status <- "api_error"
   match
 })
+output_status_counts <- table(map_chr(openalex_matches, "status"))
 
 base_result <- ojs_rows |>
   mutate(
@@ -842,7 +844,7 @@ if (run_mode == "sample") {
       c(
         "run",
         "--with", "pyarrow==21.0.0",
-        "python", "ndjson_to_parquet.py",
+        "python", "ndjson_to_parquet.py", "convert",
         shQuote(input),
         shQuote(schema),
         shQuote(output),
@@ -894,11 +896,37 @@ if (run_mode == "sample") {
   )
   unlink(source_staging_path)
 
+  jsonlite::write_json(
+    list(
+      master_rows = nrow(base_result),
+      status_counts = as.list(output_status_counts)
+    ),
+    parquet_validation_path,
+    auto_unbox = TRUE,
+    pretty = TRUE
+  )
+  validation <- system2(
+    uv,
+    c(
+      "run",
+      "--with", "pyarrow==21.0.0",
+      "python", "ndjson_to_parquet.py", "validate",
+      shQuote(output_path),
+      shQuote(source_output_path),
+      shQuote(openalex_batch_dir),
+      shQuote(parquet_validation_path)
+    ),
+    stdout = TRUE,
+    stderr = TRUE
+  )
+  if (!is.null(attr(validation, "status"))) {
+    stop(paste(validation, collapse = "\n"), call. = FALSE)
+  }
+  parquet_validation <- jsonlite::fromJSON(tail(validation, 1L))
+
   output_rows <- parquet_contract$rows
   review_result <- build_master_chunk(sample_positions)
 }
-
-output_status_counts <- table(map_chr(openalex_matches, "status"))
 
 run_metadata <- list(
   producer = "analysis/ojs_journal_enrichment.qmd",
@@ -932,6 +960,7 @@ run_metadata <- list(
   } else {
     NULL
   },
+  parquet_validation = if (run_mode == "full") parquet_validation else NULL,
   openalex = if (run_mode == "full") {
     list(
       batch_size = 100L,
@@ -1120,6 +1149,9 @@ if (run_mode == "sample") {
     identical(run_metadata$output$format, "parquet"),
     parquet_contract$columns == length(output_columns),
     source_parquet_contract$rows == length(openalex_sources),
+    parquet_validation$master_rows == 98273L,
+    parquet_validation$unique_identities == 98273L,
+    parquet_validation$catalog_rows == length(openalex_sources),
     !anyDuplicated(map_chr(openalex_sources, "id")),
     all(unique(unlist(map(openalex_matches, "candidate_ids"))) %in%
       map_chr(openalex_sources, "id")),

--- a/research/ojs-journal-metadata/analysis/ojs_journal_enrichment.qmd
+++ b/research/ojs-journal-metadata/analysis/ojs_journal_enrichment.qmd
@@ -7,9 +7,9 @@ execute:
   message: false
 ---
 
-This notebook adds the complete available OpenAlex and Crossref journal responses to ten real PKP OJS rows from the pinned V7 release. It matches records by exact ISSN. The ten rows were chosen to include missing ISSNs, no matches, one match, partial identifier coverage, and multiple matches. This Journal Enrichment Sample checks whether the code works; it does not measure coverage across the full dataset.
+This notebook adds current OpenAlex Source data to PKP OJS rows from the pinned V7 release by exact ISSN. Sample mode is the default and also checks Crossref against ten deliberately selected rows. Full mode must be started with `render_full.sh`; it checkpoints V7 OpenAlex responses and preserves all 98,273 PKP rows.
 
-Set `OPENALEX_API_KEY` in the environment or the repository-root `.env` file before rendering. Sample mode is the only mode implemented here; full-cohort retrieval remains a separate, explicit step.
+Set `OPENALEX_API_KEY` in the environment or the repository-root `.env` file before rendering. A normal render and `render_sample.sh` always use sample mode.
 
 ## Packages and paths
 
@@ -41,6 +41,9 @@ library(purrr)
 library(readr)
 library(tibble)
 
+run_mode <- Sys.getenv("OJS_ENRICHMENT_MODE", unset = "sample")
+stopifnot(run_mode %in% c("sample", "full"))
+
 project_env_path <- file.path("..", "..", "..", ".env")
 if (!nzchar(Sys.getenv("OPENALEX_API_KEY")) && file.exists(project_env_path)) {
   readRenviron(project_env_path)
@@ -58,14 +61,33 @@ pkp_md5 <- "3a4ad8ae1ebfcc2b991aaf55b2d82c92"
 artifact_dir <- file.path("..", "artifacts", "ojs_journal_enrichment")
 input_dir <- file.path(artifact_dir, "pkp-v7")
 input_path <- file.path(input_dir, "beacon.csv")
-run_dir <- file.path(artifact_dir, "sample")
-output_path <- file.path(run_dir, "pkp-ojs-multisource-enriched.csv")
+run_dir <- file.path(
+  artifact_dir,
+  if (run_mode == "full") "full-v7" else "sample"
+)
+output_path <- file.path(
+  run_dir,
+  if (run_mode == "full") {
+    "pkp-ojs-openalex-enriched.parquet"
+  } else {
+    "pkp-ojs-multisource-enriched.csv"
+  }
+)
 metadata_path <- file.path(run_dir, "run-metadata.json")
+staging_path <- file.path(run_dir, "pkp-ojs-openalex-enriched.ndjson")
+parquet_schema_path <- file.path(run_dir, "parquet-schema.json")
+source_output_path <- file.path(run_dir, "openalex-sources.parquet")
+source_staging_path <- file.path(run_dir, "openalex-sources.ndjson")
+source_schema_path <- file.path(run_dir, "openalex-sources-schema.json")
 openalex_cache_path <- file.path(run_dir, "openalex-sources.rds")
 crossref_cache_path <- file.path(run_dir, "crossref-journals.rds")
+openalex_batch_dir <- file.path(run_dir, "openalex-batches")
 
 dir.create(input_dir, recursive = TRUE, showWarnings = FALSE)
 dir.create(run_dir, recursive = TRUE, showWarnings = FALSE)
+if (run_mode == "full") {
+  dir.create(openalex_batch_dir, recursive = TRUE, showWarnings = FALSE)
+}
 
 curl <- Sys.which("curl")
 if (!nzchar(curl)) {
@@ -149,9 +171,9 @@ source_issns <- function(source) {
 
 ## Source retrieval
 
-The sample sends all valid ISSNs to OpenAlex in one request. It asks Crossref about each ISSN separately and waits between requests. A Crossref `404` means that no journal record was found.
+The sample sends all valid ISSNs to OpenAlex in one request. Full mode splits the 103,017 valid ISSNs into deterministic groups of at most 100, requests the maximum page size, follows every cursor, and atomically checkpoints each completed V7 batch. A failed batch remains an API-error state and is retried on the next run.
 
-Sample responses are cached beneath the sample run directory. Full-cohort batching, pagination, retry provenance, and checkpointing are intentionally deferred to the full-mode ticket.
+Sample mode asks Crossref about each ISSN separately and waits between requests. A Crossref `404` means that no journal record was found.
 
 ```{r}
 #| label: source-retrieval
@@ -174,6 +196,124 @@ fetch_openalex_sources <- function(
     pluck("results")
 }
 
+perform_openalex_page <- function(
+  issns,
+  cursor,
+  api_key = Sys.getenv("OPENALEX_API_KEY"),
+  max_attempts = 4L
+) {
+  stopifnot(length(issns) <= 100L, nzchar(api_key))
+
+  for (attempt in seq_len(max_attempts)) {
+    response <- tryCatch(
+      request("https://api.openalex.org/sources") |>
+        req_url_query(
+          filter = paste0("issn:", paste(issns, collapse = "|")),
+          per_page = 200,
+          cursor = cursor,
+          api_key = api_key
+        ) |>
+        req_timeout(seconds = 30) |>
+        req_error(is_error = \(response) FALSE) |>
+        req_perform(),
+      error = identity
+    )
+
+    if (!inherits(response, "condition")) {
+      status <- resp_status(response)
+      if (status < 400L) {
+        return(list(
+          ok = TRUE,
+          attempts = attempt,
+          body = resp_body_json(response, simplifyVector = FALSE)
+        ))
+      }
+      failure <- paste0("http_", status)
+      retryable <- status %in% c(403L, 429L, 500L, 502L, 503L, 504L)
+    } else {
+      failure <- "transport_error"
+      retryable <- TRUE
+    }
+
+    if (!retryable || attempt == max_attempts) {
+      return(list(
+        ok = FALSE,
+        attempts = attempt,
+        failure = failure
+      ))
+    }
+    Sys.sleep(min(2^(attempt - 1L), 8))
+  }
+}
+
+fetch_openalex_batch <- function(issns) {
+  cursor <- "*"
+  seen_cursors <- character()
+  pages <- list()
+  page_log <- list()
+  attempts <- 0L
+
+  repeat {
+    if (cursor %in% seen_cursors) {
+      return(list(
+        status = "api_error",
+        issns = issns,
+        sources = unlist(pages, recursive = FALSE),
+        pages = page_log,
+        attempts = attempts,
+        failure = "repeated_cursor",
+        pagination_complete = FALSE
+      ))
+    }
+    seen_cursors <- c(seen_cursors, cursor)
+
+    page <- perform_openalex_page(issns, cursor)
+    attempts <- attempts + page$attempts
+    if (!page$ok) {
+      return(list(
+        status = "api_error",
+        issns = issns,
+        sources = unlist(pages, recursive = FALSE),
+        pages = page_log,
+        attempts = attempts,
+        failure = page$failure,
+        pagination_complete = FALSE
+      ))
+    }
+
+    results <- if (is.null(page$body$results)) list() else page$body$results
+    next_cursor <- page$body$meta$next_cursor
+    pages[[length(pages) + 1L]] <- results
+    page_log[[length(page_log) + 1L]] <- list(
+      result_count = length(results),
+      attempts = page$attempts,
+      retrieved_at = format(Sys.time(), tz = "UTC", usetz = TRUE)
+    )
+    if (is.null(next_cursor) || !nzchar(next_cursor)) break
+    cursor <- next_cursor
+  }
+
+  list(
+    status = "complete",
+    issns = issns,
+    sources = unlist(pages, recursive = FALSE),
+    pages = page_log,
+    attempts = attempts,
+    failure = NULL,
+    pagination_complete = TRUE
+  )
+}
+
+save_rds_atomic <- function(value, path) {
+  temporary <- paste0(path, ".tmp")
+  saveRDS(value, temporary)
+  if (!file.rename(temporary, path)) {
+    unlink(temporary)
+    stop("Could not checkpoint OpenAlex batch.", call. = FALSE)
+  }
+  invisible(path)
+}
+
 fetch_crossref_journal <- function(issn) {
   response <- request(paste0("https://api.crossref.org/journals/", issn)) |>
     req_timeout(seconds = 30) |>
@@ -189,9 +329,9 @@ fetch_crossref_journal <- function(issn) {
 
 ```
 
-## Load the Journal Enrichment Sample
+## Load the PKP V7 rows
 
-The pinned PKP V7 file is Dataverse file `14084919`, released on 2026-07-18. This chunk checks the complete 98,273-row baseline, schema, row identity, and identifier counts before selecting ten fixed source rows in a deliberate display order.
+The pinned PKP V7 file is Dataverse file `14084919`, released on 2026-07-18. This chunk checks the complete 98,273-row baseline, schema, row identity, and identifier counts before either retaining the full cohort or selecting ten fixed source rows in a deliberate display order.
 
 ```{r}
 #| label: load-sample
@@ -291,17 +431,23 @@ sample_identity <- row_identity(sample_spec)
 sample_positions <- match(sample_identity, raw_row_identity)
 stopifnot(!anyNA(sample_positions))
 
-ojs_rows <- raw_input[sample_positions, ] |>
+sample_rows <- raw_input[sample_positions, ] |>
   select(-any_of("admin_email"))
 stopifnot(
-  nrow(ojs_rows) == 10L,
-  identical(ojs_rows$context_name, sample_spec$context_name)
+  nrow(sample_rows) == 10L,
+  identical(sample_rows$context_name, sample_spec$context_name)
 )
+
+ojs_rows <- if (run_mode == "full") {
+  raw_input |> select(-any_of("admin_email"))
+} else {
+  sample_rows
+}
 ```
 
 ## Multi-source enrichment
 
-For each PKP row, the sample looks for OpenAlex and Crossref records with the same ISSN. If the same source record appears more than once, it is counted once. Every returned top-level API field becomes a dataframe column; nested objects and arrays are stored as JSON in their field columns, and the complete candidate lists are also retained as lossless JSON.
+For each PKP row, the sample looks for OpenAlex and Crossref records with the same ISSN. If the same source record appears more than once, it is counted once. Sample mode expands returned fields for review. Full mode keeps candidate IDs in the one-row-per-PKP master and indexes each unique Source ID to its complete V7 checkpoint response in a companion Parquet catalog.
 
 ### Sample matching helpers
 
@@ -331,6 +477,32 @@ deduplicate_candidates <- function(candidates, identity) {
     candidates = candidates[keep],
     candidate_ids = candidate_ids[keep]
   )
+}
+
+index_candidates_by_issn <- function(candidates, candidate_issns) {
+  index <- new.env(hash = TRUE, parent = emptyenv())
+  for (candidate_position in seq_along(candidates)) {
+    for (issn in candidate_issns(candidates[[candidate_position]])) {
+      positions <- if (exists(issn, index, inherits = FALSE)) {
+        get(issn, index, inherits = FALSE)
+      } else {
+        integer()
+      }
+      assign(issn, c(positions, candidate_position), index)
+    }
+  }
+  index
+}
+
+candidates_for_issns <- function(candidates, index, issns) {
+  positions <- unique(unlist(map(issns, \(issn) {
+    if (exists(issn, index, inherits = FALSE)) {
+      get(issn, index, inherits = FALSE)
+    } else {
+      integer()
+    }
+  })))
+  candidates[positions]
 }
 
 match_exact_issns <- function(
@@ -405,75 +577,116 @@ expand_candidate_fields <- function(match, prefix) {
 }
 ```
 
-### Sample enrichment orchestration
+### Enrichment orchestration
 
-This chunk collects the unique sample ISSNs, retrieves or reuses source records, matches them to the PKP rows, adds every returned source field, and writes one CSV row for each PKP row. The first candidate uses the ordinary source prefix; additional candidates use numbered prefixes so inconsistent matches remain complete and auditable.
+Both modes use the same exact-ISSN matcher. Full mode indexes candidates by normalized ISSN so matching 98,273 rows does not repeatedly scan the complete Source response set. Candidate IDs connect the compact master to the Source catalog and lossless V7 checkpoints, so inconsistent identities remain complete without duplicating large Source JSON.
 
 ```{r}
-#| label: sample-enrichment
+#| label: enrichment
 
 input_issns <- map(ojs_rows$issn, parse_issns)
 tokens <- sort(unique(unlist(input_issns)))
 
-openalex_cache_hit <- file.exists(openalex_cache_path)
-openalex_sources <- if (openalex_cache_hit) {
-  readRDS(openalex_cache_path)
-} else {
-  sources <- fetch_openalex_sources(tokens)
-  saveRDS(sources, openalex_cache_path)
-  sources
-}
+if (run_mode == "full") {
+  token_batches <- split(tokens, ceiling(seq_along(tokens) / 100L))
+  process_batch <- function(batch_index) {
+    batch <- token_batches[[batch_index]]
+    checkpoint_path <- file.path(
+      openalex_batch_dir,
+      sprintf("batch-%04d.rds", batch_index)
+    )
+    checkpoint <- if (file.exists(checkpoint_path)) {
+      tryCatch(readRDS(checkpoint_path), error = \(error) NULL)
+    } else {
+      NULL
+    }
+    reusable <- !is.null(checkpoint) &&
+      identical(checkpoint$pkp_version, pkp_version) &&
+      identical(checkpoint$input_md5, pkp_md5) &&
+      identical(checkpoint$issns, batch) &&
+      identical(checkpoint$status, "complete") &&
+      isTRUE(checkpoint$pagination_complete)
 
-crossref_cache_hit <- file.exists(crossref_cache_path)
-crossref_journals <- if (crossref_cache_hit) {
-  readRDS(crossref_cache_path)
-} else {
-  journals <- set_names(
-    map(tokens, \(token) {
-      journal <- fetch_crossref_journal(token)
-      Sys.sleep(0.25)
-      journal
-    }),
-    tokens
+    if (reusable) {
+      checkpoint$reused <- TRUE
+      return(checkpoint)
+    }
+
+    checkpoint <- fetch_openalex_batch(batch)
+    checkpoint$pkp_version <- pkp_version
+    checkpoint$input_md5 <- pkp_md5
+    checkpoint$batch_index <- as.integer(batch_index)
+    checkpoint$reused <- FALSE
+    save_rds_atomic(checkpoint, checkpoint_path)
+    checkpoint
+  }
+  openalex_cluster <- parallel::makeCluster(4L)
+  invisible(parallel::clusterEvalQ(openalex_cluster, library(httr2)))
+  parallel::clusterExport(
+    openalex_cluster,
+    c(
+      "token_batches",
+      "openalex_batch_dir",
+      "pkp_version",
+      "pkp_md5",
+      "perform_openalex_page",
+      "fetch_openalex_batch",
+      "save_rds_atomic",
+      "process_batch"
+    ),
+    envir = environment()
   )
-  saveRDS(journals, crossref_cache_path)
-  journals
+  batch_results <- tryCatch(
+    parallel::parLapplyLB(
+      openalex_cluster,
+      seq_along(token_batches),
+      process_batch
+    ),
+    finally = parallel::stopCluster(openalex_cluster)
+  )
+  openalex_cache_hit <- all(map_lgl(batch_results, "reused"))
+  openalex_sources <- unlist(
+    map(batch_results, "sources"),
+    recursive = FALSE
+  )
+  failed_issns <- unique(unlist(map(
+    keep(batch_results, \(batch) batch$status != "complete"),
+    "issns"
+  )))
+} else {
+  token_batches <- list(tokens)
+  batch_results <- list()
+  failed_issns <- character()
+  openalex_cache_hit <- file.exists(openalex_cache_path)
+  openalex_sources <- if (openalex_cache_hit) {
+    readRDS(openalex_cache_path)
+  } else {
+    sources <- fetch_openalex_sources(tokens)
+    saveRDS(sources, openalex_cache_path)
+    sources
+  }
 }
-crossref_candidates <- unname(compact(crossref_journals))
+openalex_sources <- deduplicate_candidates(
+  openalex_sources,
+  \(source) source$id
+)$candidates
+openalex_index <- index_candidates_by_issn(
+  openalex_sources,
+  source_issns
+)
 
 openalex_matches <- map(input_issns, \(issns) {
-  match_exact_issns(
+  match <- match_exact_issns(
     issns,
-    openalex_sources,
+    candidates_for_issns(openalex_sources, openalex_index, issns),
     source_issns,
     \(source) source$id
   )
+  if (any(issns %in% failed_issns)) match$status <- "api_error"
+  match
 })
 
-crossref_matches <- map(input_issns, \(issns) {
-  match_exact_issns(
-    issns,
-    crossref_candidates,
-    \(journal) {
-      issns <- vapply(journal$ISSN, normalize_issn, character(1))
-      unique(issns[!is.na(issns)])
-    },
-    crossref_key
-  )
-})
-
-openalex_data <- map_dfr(
-  openalex_matches,
-  expand_candidate_fields,
-  prefix = "openalex"
-)
-crossref_data <- map_dfr(
-  crossref_matches,
-  expand_candidate_fields,
-  prefix = "crossref"
-)
-
-result <- ojs_rows |>
+base_result <- ojs_rows |>
   mutate(
     identifier_status = case_when(
       is_missing_identifier(issn) ~ "missing",
@@ -486,28 +699,210 @@ result <- ojs_rows |>
       \(match) paste(match$matched_issns, collapse = "|")
     ),
     openalex_match_status = map_chr(openalex_matches, "status"),
+    openalex_candidate_count = map_int(
+      openalex_matches,
+      \(match) length(match$candidate_ids)
+    ),
     openalex_candidate_ids = map_chr(
       openalex_matches,
       \(match) paste(match$candidate_ids, collapse = "|")
-    ),
-    crossref_input_issns = map_chr(input_issns, paste, collapse = "|"),
-    crossref_matched_issns = map_chr(
-      crossref_matches,
-      \(match) paste(match$matched_issns, collapse = "|")
-    ),
-    crossref_match_status = map_chr(crossref_matches, "status"),
-    crossref_candidate_issn_sets = map_chr(
-      crossref_matches,
-      \(match) paste(match$candidate_ids, collapse = ";")
     )
-  ) |>
-  bind_cols(openalex_data, crossref_data)
+  )
 
-write_csv(result, output_path, na = "")
+if (run_mode == "sample") {
+  openalex_data <- map_dfr(
+    openalex_matches,
+    expand_candidate_fields,
+    prefix = "openalex"
+  )
+  result <- bind_cols(base_result, openalex_data)
+  crossref_cache_hit <- file.exists(crossref_cache_path)
+  crossref_journals <- if (crossref_cache_hit) {
+    readRDS(crossref_cache_path)
+  } else {
+    journals <- set_names(
+      map(tokens, \(token) {
+        journal <- fetch_crossref_journal(token)
+        Sys.sleep(0.25)
+        journal
+      }),
+      tokens
+    )
+    saveRDS(journals, crossref_cache_path)
+    journals
+  }
+  crossref_candidates <- unname(compact(crossref_journals))
+  crossref_index <- index_candidates_by_issn(
+    crossref_candidates,
+    \(journal) {
+      issns <- vapply(journal$ISSN, normalize_issn, character(1))
+      unique(issns[!is.na(issns)])
+    }
+  )
+  crossref_matches <- map(input_issns, \(issns) {
+    match_exact_issns(
+      issns,
+      candidates_for_issns(
+        crossref_candidates,
+        crossref_index,
+        issns
+      ),
+      \(journal) {
+        issns <- vapply(journal$ISSN, normalize_issn, character(1))
+        unique(issns[!is.na(issns)])
+      },
+      crossref_key
+    )
+  })
+  crossref_data <- map_dfr(
+    crossref_matches,
+    expand_candidate_fields,
+    prefix = "crossref"
+  )
+  result <- result |>
+    mutate(
+      crossref_input_issns = map_chr(input_issns, paste, collapse = "|"),
+      crossref_matched_issns = map_chr(
+        crossref_matches,
+        \(match) paste(match$matched_issns, collapse = "|")
+      ),
+      crossref_match_status = map_chr(crossref_matches, "status"),
+      crossref_candidate_issn_sets = map_chr(
+        crossref_matches,
+        \(match) paste(match$candidate_ids, collapse = ";")
+      )
+    ) |>
+    bind_cols(crossref_data)
+  write_csv(result, output_path, na = "")
+  output_rows <- nrow(result)
+  output_columns <- names(result)
+  review_result <- result
+} else {
+  crossref_cache_hit <- FALSE
+  crossref_matches <- list()
+  source_fields <- sort(unique(unlist(map(openalex_sources, names))))
+  output_columns <- names(base_result)
+  source_output_columns <- c("openalex_source_id", "checkpoint_file")
+  checkpoint_by_source <- new.env(hash = TRUE, parent = emptyenv())
+  for (batch in batch_results) {
+    checkpoint_file <- sprintf("batch-%04d.rds", batch$batch_index)
+    for (source in batch$sources) {
+      if (!exists(source$id, checkpoint_by_source, inherits = FALSE)) {
+        assign(source$id, checkpoint_file, checkpoint_by_source)
+      }
+    }
+  }
+
+  build_master_chunk <- function(indices) {
+    chunk <- as.data.frame(base_result[indices, ], stringsAsFactors = FALSE)
+    chunk[] <- lapply(chunk, as.character)
+    chunk[output_columns]
+  }
+
+  build_source_chunk <- function(indices) {
+    source_ids <- unname(map_chr(openalex_sources[indices], "id"))
+    data.frame(
+      openalex_source_id = source_ids,
+      checkpoint_file = unname(vapply(
+        source_ids,
+        get,
+        character(1),
+        envir = checkpoint_by_source,
+        inherits = FALSE
+      )),
+      stringsAsFactors = FALSE
+    )
+  }
+
+  write_ndjson_chunks <- function(path, rows, builder) {
+    unlink(path)
+    connection <- file(path, open = "wb")
+    tryCatch(
+      {
+        for (start in seq.int(1L, rows, by = 1000L)) {
+          indices <- start:min(start + 999L, rows)
+          jsonlite::stream_out(
+            builder(indices),
+            connection,
+            verbose = FALSE
+          )
+        }
+      },
+      finally = close(connection)
+    )
+  }
+
+  uv <- Sys.which("uv")
+  if (!nzchar(uv)) {
+    stop("uv is required to write the full Parquet artifacts.", call. = FALSE)
+  }
+  convert_to_parquet <- function(input, schema, output, expected_rows) {
+    conversion <- system2(
+      uv,
+      c(
+        "run",
+        "--with", "pyarrow==21.0.0",
+        "python", "ndjson_to_parquet.py",
+        shQuote(input),
+        shQuote(schema),
+        shQuote(output),
+        "--expected-rows", expected_rows
+      ),
+      stdout = TRUE,
+      stderr = TRUE
+    )
+    if (!is.null(attr(conversion, "status"))) {
+      stop(paste(conversion, collapse = "\n"), call. = FALSE)
+    }
+    jsonlite::fromJSON(tail(conversion, 1L))
+  }
+
+  write_ndjson_chunks(staging_path, nrow(base_result), build_master_chunk)
+  jsonlite::write_json(
+    list(columns = output_columns),
+    parquet_schema_path,
+    auto_unbox = TRUE,
+    pretty = TRUE
+  )
+  parquet_contract <- convert_to_parquet(
+    staging_path,
+    parquet_schema_path,
+    output_path,
+    nrow(base_result)
+  )
+  unlink(staging_path)
+
+  write_ndjson_chunks(
+    source_staging_path,
+    length(openalex_sources),
+    build_source_chunk
+  )
+  jsonlite::write_json(
+    list(
+      columns = source_output_columns,
+      source_fields = source_fields
+    ),
+    source_schema_path,
+    auto_unbox = TRUE,
+    pretty = TRUE
+  )
+  source_parquet_contract <- convert_to_parquet(
+    source_staging_path,
+    source_schema_path,
+    source_output_path,
+    length(openalex_sources)
+  )
+  unlink(source_staging_path)
+
+  output_rows <- parquet_contract$rows
+  review_result <- build_master_chunk(sample_positions)
+}
+
+output_status_counts <- table(map_chr(openalex_matches, "status"))
 
 run_metadata <- list(
   producer = "analysis/ojs_journal_enrichment.qmd",
-  run_mode = "sample",
+  run_mode = run_mode,
   created_at = format(Sys.time(), tz = "UTC", usetz = TRUE),
   input = list(
     version = pkp_version,
@@ -518,25 +913,59 @@ run_metadata <- list(
     missing_identifier_rows = sum(missing_identifier),
     distinct_valid_issns = length(unique(unlist(all_input_issns)))
   ),
-  sample_rows = nrow(result),
   output = list(
     file = basename(output_path),
-    md5 = unname(tools::md5sum(output_path))
+    md5 = unname(tools::md5sum(output_path)),
+    format = if (run_mode == "full") "parquet" else "csv",
+    rows = output_rows,
+    columns = length(output_columns),
+    status_counts = as.list(output_status_counts)
   ),
-  cache = list(
-    openalex = list(
-      file = basename(openalex_cache_path),
+  source_catalog = if (run_mode == "full") {
+    list(
+      file = basename(source_output_path),
+      md5 = unname(tools::md5sum(source_output_path)),
+      rows = source_parquet_contract$rows,
+      columns = source_parquet_contract$columns,
+      retained_top_level_fields = source_fields
+    )
+  } else {
+    NULL
+  },
+  openalex = if (run_mode == "full") {
+    list(
+      batch_size = 100L,
+      per_page = 200L,
+      batches = length(batch_results),
+      completed_batches = sum(map_chr(batch_results, "status") == "complete"),
+      reused_batches = sum(map_lgl(batch_results, "reused")),
+      pages = sum(map_int(batch_results, \(batch) length(batch$pages))),
+      attempts = sum(map_int(batch_results, "attempts")),
+      failed_batches = sum(map_chr(batch_results, "status") != "complete")
+    )
+  } else {
+    list(
+      cache_file = basename(openalex_cache_path),
       reused = openalex_cache_hit
-    ),
-    crossref = list(
-      file = basename(crossref_cache_path),
+    )
+  },
+  crossref = if (run_mode == "sample") {
+    list(
+      cache_file = basename(crossref_cache_path),
       reused = crossref_cache_hit
     )
-  ),
+  } else {
+    list(status = "not_attempted")
+  },
   runtime = list(
     r = R.version.string,
     quarto = system2("quarto", "--version", stdout = TRUE)[1],
     curl = system2(curl, "--version", stdout = TRUE)[1],
+    pyarrow = if (run_mode == "full") {
+      source_parquet_contract$pyarrow
+    } else {
+      "not used"
+    },
     packages = as.list(set_names(
       vapply(
         required_packages,
@@ -557,33 +986,11 @@ jsonlite::write_json(
 
 ## Checks
 
-These checks confirm that every input row appears in the output, every returned top-level API field is retained, the lossless candidate JSON matches the fetched records, the CSV file was written, and the sample contains the expected match outcomes.
+These checks confirm that every input row appears in the master, every returned top-level API field remains in the lossless Source catalog, candidate IDs reconcile, credentials stay private, and full-mode pagination completed without unresolved API failures.
 
 ```{r}
 #| label: contract-check
 
-expected_openalex_columns <- unique(unlist(map(
-  openalex_matches,
-  candidate_field_names,
-  prefix = "openalex"
-)))
-expected_crossref_columns <- unique(unlist(map(
-  crossref_matches,
-  candidate_field_names,
-  prefix = "crossref"
-)))
-expected_openalex_status <- c(
-  "consistent",
-  "consistent",
-  "unmatched",
-  "consistent",
-  "consistent",
-  "consistent",
-  "consistent",
-  "consistent",
-  "not_attempted",
-  "inconsistent"
-)
 metadata_text <- paste(readLines(metadata_path, warn = FALSE), collapse = "\n")
 artifact_root <- normalizePath(artifact_dir)
 
@@ -596,12 +1003,6 @@ stopifnot(
   sum(missing_identifier) == 26189L,
   sum(lengths(all_input_issns) > 0L) == 72084L,
   length(unique(unlist(all_input_issns))) == 103017L,
-  identical(
-    row_identity(ojs_rows),
-    sample_identity
-  ),
-  sum(result$identifier_status == "missing") == 1L,
-  nrow(result) == 10L,
   startsWith(normalizePath(input_path), artifact_root),
   startsWith(normalizePath(output_path), artifact_root),
   startsWith(normalizePath(metadata_path), artifact_root),
@@ -614,62 +1015,141 @@ stopifnot(
     "row_identity",
     "match_exact_issns",
     "deduplicate_candidates",
+    "index_candidates_by_issn",
+    "candidates_for_issns",
     "expand_candidate_fields",
     "serialize_json"
   ), exists, logical(1), mode = "function")),
   exists("fetch_openalex_sources", mode = "function"),
   exists("fetch_crossref_journal", mode = "function"),
-  nrow(result) == nrow(ojs_rows),
+  output_rows == nrow(ojs_rows),
   file.exists(output_path),
   all(c(
     "openalex_match_status",
-    "openalex_id",
-    "openalex_summary_stats",
-    "openalex_topics",
-    "openalex_candidate_2_id",
-    "openalex_candidates__json",
-    "crossref_match_status",
-    "crossref_title",
-    "crossref_counts",
-    "crossref_coverage",
-    "crossref_candidates__json"
-  ) %in% names(result)),
-  all(expected_openalex_columns %in% names(result)),
-  all(expected_crossref_columns %in% names(result)),
+    "openalex_candidate_count",
+    "openalex_candidate_ids"
+  ) %in% output_columns),
   identical(
-    result$openalex_candidates__json,
-    map_chr(openalex_matches, \(match) serialize_json(match$candidates))
+    base_result$openalex_candidate_count,
+    map_int(openalex_matches, \(match) length(match$candidate_ids))
   ),
-  identical(
-    result$crossref_candidates__json,
-    map_chr(crossref_matches, \(match) serialize_json(match$candidates))
-  ),
-  identical(result$openalex_match_status, expected_openalex_status),
-  result$openalex_matched_issns[
-    result$context_name == "Jami Scientific Research Quarterly Journal"
-  ] == "2710-4990",
-  "not_attempted" %in% result$crossref_match_status
+  all(base_result$openalex_match_status %in% c(
+    "consistent",
+    "inconsistent",
+    "unmatched",
+    "not_attempted",
+    "api_error"
+  )),
+  sum(unlist(run_metadata$output$status_counts)) == output_rows,
+  !"admin_email" %in% output_columns
 )
+
+if (run_mode == "sample") {
+  expected_openalex_columns <- unique(unlist(map(
+    openalex_matches,
+    candidate_field_names,
+    prefix = "openalex"
+  )))
+  expected_openalex_status <- c(
+    "consistent",
+    "consistent",
+    "unmatched",
+    "consistent",
+    "consistent",
+    "consistent",
+    "consistent",
+    "consistent",
+    "not_attempted",
+    "inconsistent"
+  )
+  expected_crossref_columns <- unique(unlist(map(
+    crossref_matches,
+    candidate_field_names,
+    prefix = "crossref"
+  )))
+  stopifnot(
+    identical(row_identity(ojs_rows), sample_identity),
+    sum(result$identifier_status == "missing") == 1L,
+    nrow(result) == 10L,
+    all(c(
+      "openalex_id",
+      "openalex_summary_stats",
+      "openalex_topics",
+      "openalex_candidates__json",
+      "openalex_candidate_2_id",
+      "crossref_match_status",
+      "crossref_title",
+      "crossref_counts",
+      "crossref_coverage",
+      "crossref_candidates__json"
+    ) %in% names(result)),
+    all(expected_openalex_columns %in% names(result)),
+    all(expected_crossref_columns %in% names(result)),
+    identical(
+      result$openalex_candidates__json,
+      map_chr(openalex_matches, \(match) serialize_json(match$candidates))
+    ),
+    identical(
+      result$crossref_candidates__json,
+      map_chr(crossref_matches, \(match) serialize_json(match$candidates))
+    ),
+    identical(result$openalex_match_status, expected_openalex_status),
+    result$openalex_matched_issns[
+      result$context_name == "Jami Scientific Research Quarterly Journal"
+    ] == "2710-4990",
+    "not_attempted" %in% result$crossref_match_status
+  )
+} else {
+  stopifnot(
+    identical(row_identity(ojs_rows), raw_row_identity),
+    output_rows == 98273L,
+    sum(base_result$identifier_status == "missing") == 26189L,
+    length(tokens) == 103017L,
+    length(token_batches) == 1031L,
+    max(lengths(token_batches)) <= 100L,
+    all(map_lgl(batch_results, \(batch) {
+      identical(batch$pkp_version, 7L) &&
+        identical(batch$input_md5, pkp_md5) &&
+        identical(batch$status, "complete") &&
+        isTRUE(batch$pagination_complete) &&
+        length(batch$pages) >= 1L
+    })),
+    run_metadata$openalex$completed_batches == length(token_batches),
+    run_metadata$openalex$failed_batches == 0L,
+    !any(base_result$openalex_match_status == "api_error"),
+    identical(run_metadata$output$format, "parquet"),
+    parquet_contract$columns == length(output_columns),
+    source_parquet_contract$rows == length(openalex_sources),
+    !anyDuplicated(map_chr(openalex_sources, "id")),
+    all(unique(unlist(map(openalex_matches, "candidate_ids"))) %in%
+      map_chr(openalex_sources, "id")),
+    length(run_metadata$source_catalog$retained_top_level_fields) ==
+      length(source_fields),
+    file.exists(source_output_path),
+    !file.exists(staging_path),
+    !file.exists(source_staging_path)
+  )
+}
 ```
 
 ## Complete merged dataframe
 
-This table displays all OJS, OpenAlex, and Crossref columns in the merged sample dataframe.
+This table displays all columns for the ten purposive review rows. In full mode the complete 98,273-row result stays in the master Parquet file while the report remains inspectable.
 
 ```{r}
 #| label: complete-sample-dataframe
 
-result |>
+review_result |>
   knitr::kable(format = "html")
 ```
 
 ## Complete merged column list
 
-This table lists every column in the CSV so collaborators can review its structure.
+This table lists every column in the master artifact so collaborators can review its structure.
 
 ```{r}
 #| label: complete-column-list
 
-tibble(column = names(result)) |>
+tibble(column = output_columns) |>
   knitr::kable()
 ```

--- a/research/ojs-journal-metadata/analysis/render_full.sh
+++ b/research/ojs-journal-metadata/analysis/render_full.sh
@@ -16,8 +16,17 @@ test -f "$artifact_dir/full-v7/run-metadata.json"
 test -f "$artifact_dir/full-v7/pkp-ojs-multisource-enriched.parquet"
 test -f "$artifact_dir/full-v7/openalex-sources.parquet"
 test -f "$artifact_dir/full-v7/crossref-journals.parquet"
+test -f "$artifact_dir/full-v7/pkp-openalex-disagreement-audit.csv"
+test -f "$artifact_dir/full-v7/pkp-openalex-disagreement-summary.csv"
 grep -q '"run_mode": "full"' "$artifact_dir/full-v7/run-metadata.json"
 grep -q '"rows": 98273' "$artifact_dir/full-v7/run-metadata.json"
 grep -q '"format": "parquet"' "$artifact_dir/full-v7/run-metadata.json"
 grep -q '"rows_per_page": 1000' "$artifact_dir/full-v7/run-metadata.json"
 grep -q '"failed_pages": 0' "$artifact_dir/full-v7/run-metadata.json"
+grep -q '"disagreement_audit"' "$artifact_dir/full-v7/run-metadata.json"
+grep -q '^dimension,category,denominator_name,denominator,count,percent$' \
+  "$artifact_dir/full-v7/pkp-openalex-disagreement-summary.csv"
+grep -q '^identity_outcome,consistent,all_pkp_v7_rows,98273,' \
+  "$artifact_dir/full-v7/pkp-openalex-disagreement-summary.csv"
+grep -q '^source_status_crosstab,openalex=' \
+  "$artifact_dir/full-v7/pkp-openalex-disagreement-summary.csv"

--- a/research/ojs-journal-metadata/analysis/render_full.sh
+++ b/research/ojs-journal-metadata/analysis/render_full.sh
@@ -13,8 +13,11 @@ OJS_ENRICHMENT_MODE=full quarto render ojs_journal_enrichment.qmd \
   --output-dir ../rendered-full
 
 test -f "$artifact_dir/full-v7/run-metadata.json"
-test -f "$artifact_dir/full-v7/pkp-ojs-openalex-enriched.parquet"
+test -f "$artifact_dir/full-v7/pkp-ojs-multisource-enriched.parquet"
 test -f "$artifact_dir/full-v7/openalex-sources.parquet"
+test -f "$artifact_dir/full-v7/crossref-journals.parquet"
 grep -q '"run_mode": "full"' "$artifact_dir/full-v7/run-metadata.json"
 grep -q '"rows": 98273' "$artifact_dir/full-v7/run-metadata.json"
 grep -q '"format": "parquet"' "$artifact_dir/full-v7/run-metadata.json"
+grep -q '"rows_per_page": 1000' "$artifact_dir/full-v7/run-metadata.json"
+grep -q '"failed_pages": 0' "$artifact_dir/full-v7/run-metadata.json"

--- a/research/ojs-journal-metadata/analysis/render_full.sh
+++ b/research/ojs-journal-metadata/analysis/render_full.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+analysis_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+artifact_dir="$analysis_dir/../artifacts/ojs_journal_enrichment"
+render_source_dir="$artifact_dir/render-source-full"
+
+mkdir -p "$render_source_dir"
+cp "$analysis_dir/ojs_journal_enrichment.qmd" "$render_source_dir/"
+cd "$render_source_dir"
+OJS_ENRICHMENT_MODE=full quarto render ojs_journal_enrichment.qmd \
+  --execute-dir "$analysis_dir" \
+  --output-dir ../rendered-full
+
+test -f "$artifact_dir/full-v7/run-metadata.json"
+grep -q '"run_mode": "full"' "$artifact_dir/full-v7/run-metadata.json"
+grep -q '"rows": 98273' "$artifact_dir/full-v7/run-metadata.json"

--- a/research/ojs-journal-metadata/analysis/render_full.sh
+++ b/research/ojs-journal-metadata/analysis/render_full.sh
@@ -13,5 +13,8 @@ OJS_ENRICHMENT_MODE=full quarto render ojs_journal_enrichment.qmd \
   --output-dir ../rendered-full
 
 test -f "$artifact_dir/full-v7/run-metadata.json"
+test -f "$artifact_dir/full-v7/pkp-ojs-openalex-enriched.parquet"
+test -f "$artifact_dir/full-v7/openalex-sources.parquet"
 grep -q '"run_mode": "full"' "$artifact_dir/full-v7/run-metadata.json"
 grep -q '"rows": 98273' "$artifact_dir/full-v7/run-metadata.json"
+grep -q '"format": "parquet"' "$artifact_dir/full-v7/run-metadata.json"

--- a/research/ojs-journal-metadata/analysis/render_sample.sh
+++ b/research/ojs-journal-metadata/analysis/render_sample.sh
@@ -8,6 +8,6 @@ render_source_dir="$artifact_dir/render-source"
 mkdir -p "$render_source_dir"
 cp "$analysis_dir/ojs_journal_enrichment.qmd" "$render_source_dir/"
 cd "$render_source_dir"
-exec quarto render ojs_journal_enrichment.qmd \
+exec env OJS_ENRICHMENT_MODE=sample quarto render ojs_journal_enrichment.qmd \
   --execute-dir "$analysis_dir" \
   --output-dir ../rendered


### PR DESCRIPTION
## Summary

Closes the delivery gap for PRD #98 by integrating tickets #100, #101, and #102 on top of the already-delivered V7 sample work in #99.

- add explicit, resumable OpenAlex full-cohort enrichment
- add polite, resumable Crossref journal-directory retrieval and local exact-ISSN matching
- add the PKP–OpenAlex disagreement audit, denominator-explicit summaries, visualizations, and interactive review table
- preserve complete source evidence in checkpoints/catalogs while keeping the 98,273-row master compact in Parquet

## Why

The previous notebook exposed only the ten-row validation sample. This change makes the pinned PKP V7 cohort reproducible end to end without a private cloud data root, while keeping sample mode safe by default and full mode explicit.

The original repeated wide-CSV design was replaced with a compact Parquet master plus deduplicated catalogs after real execution showed excessive CPU, memory, and JSON serialization cost. Complete source objects remain losslessly available in atomic checkpoints.

## Validation

- `./render_sample.sh`: PASS
- `CROSSREF_MAILTO=<process config> ./render_full.sh`: PASS on the final commit
- full input: 98,273 PKP V7 rows; 103,017 distinct valid ISSNs
- OpenAlex: 1,031/1,031 batches complete/reused; 0 failed batches
- Crossref: 168,654 journals over 169/169 pages complete/reused; 0 failed pages
- post-write validation: 98,273 unique PKP identities, 54,520 OpenAlex catalog rows, 137,473 Crossref catalog rows
- disagreement audit: 98,273 rows plus a 54-row denominator-explicit summary
- `git diff --check`: PASS
- repository suite in a complete declared dependency environment: 24 passed, 3 unrelated baseline failures; the branch does not modify the article-conversion or publication-compendium paths, and the owner-contract failure predates this PR

## Boundaries

Generated outputs remain ignored local Exploratory Analysis artifacts. This PR does not deliver to the collaborator repository, designate Paper Analysis, or introduce predictive or causal claims.
