### PR TITLE
Separate OJS enrichment and disagreement analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,8 @@ data/validation/validation_progress.json
 research/*/artifacts/
 research/*/analysis/*.html
 research/*/analysis/*_files/
+research/*/analysis/.Rhistory
+research/*/analysis/rsconnect/
 
 # Raw Intake Inbox bytes are local-only and non-authoritative.
 inbox/*

--- a/docs/plans/2026-07-30-ojs-enrichment-simplification-design.md
+++ b/docs/plans/2026-07-30-ojs-enrichment-simplification-design.md
@@ -1,0 +1,66 @@
+# OJS Enrichment Simplification Design
+
+## Decision
+
+Separate reusable data production from exploratory disagreement analysis.
+
+The enrichment notebook produces one reusable wide master CSV with one pinned
+PKP V7 row per output row. A separate analysis notebook reads that master and
+performs the complete PKP–OpenAlex disagreement analysis. The analysis notebook
+does not call OpenAlex or Crossref.
+
+## Enrichment notebook
+
+`research/ojs-journal-metadata/analysis/ojs_journal_enrichment.qmd` will:
+
+- verify the pinned PKP V7 input and exact row identities;
+- normalize checksum-valid ISSNs;
+- retrieve OpenAlex and Crossref data with bounded retries, pacing, and
+  resumable internal RDS checkpoints;
+- preserve every PKP row and exact-ISSN match status;
+- expand every returned top-level OpenAlex and Crossref field into the master,
+  serializing nested or repeated values as lossless JSON cells;
+- retain complete candidate records for ambiguous matches;
+- write and reread one compressed wide master CSV before promotion; and
+- render basic run counts plus the fixed searchable ten-row review.
+
+The RDS caches and checkpoints are internal, ignored, and reproducible. They
+are not formal data deliverables.
+
+## Disagreement analysis notebook
+
+`research/ojs-journal-metadata/analysis/ojs_journal_disagreement_analysis.qmd`
+will read the validated wide master and preserve the existing exploratory
+analysis:
+
+- seven exact-ISSN identity outcomes;
+- normalized title, ISSN-set, OJS, DOAJ, and country comparisons;
+- explicit eligible denominators and source-status cross-tabulation;
+- disagreement detail and summary tables; and
+- the existing descriptive charts and review table.
+
+Its outputs remain exploratory generated artifacts. The notebook reports
+source-specific differences without treating either source as authoritative or
+source absence as a causal measure of journal invisibility.
+
+## Removed enrichment responsibilities
+
+The enrichment notebook will no longer produce or validate:
+
+- Parquet or NDJSON artifacts;
+- OpenAlex or Crossref pointer catalogs;
+- schema or validation manifests;
+- a disagreement audit or disagreement summary;
+- disagreement charts; or
+- analysis-specific metadata.
+
+## Validation
+
+The retained public seam is a complete render plus artifact checks:
+
+- sample render: ten source-authentic rows and complete wide source fields;
+- full render: 98,273 unique PKP identities in one wide master CSV;
+- analysis render: all identity and metadata summaries reconcile to the master;
+- no API credentials or `admin_email` appear in outputs; and
+- caches may be deleted and rebuilt without changing the formal output
+  contract.

--- a/docs/testing/ojs-journal-enrichment-qmd.tdd.md
+++ b/docs/testing/ojs-journal-enrichment-qmd.tdd.md
@@ -319,3 +319,43 @@ neither observed; the corrected disagreement rate is 9.082%, not the previous
 tracked generated HTML and Quarto dependency directory were removed, and all
 future reports, caches, package libraries, and profiles remain under the
 owner's ignored `artifacts/ojs_journal_enrichment/` directory.
+
+## 2026-07-30 wide master and separated difference analysis
+
+The user confirmed that the full difference analysis remains valuable but is
+not part of enrichment. The enrichment QMD now has one formal data deliverable:
+a wide CSV.gz master. A separate offline QMD reads that master and owns all
+difference classifications, summaries, charts, and review output.
+
+### Task report
+
+| Stage | Commit or command | Evidence |
+|---|---|---|
+| RED | `c973d5b`; targeted pytest | Two expected failures showed that enrichment still emitted analysis artifacts and the separate QMD did not exist. A follow-up RED rejected dynamic candidate-number columns. |
+| Static GREEN | `uv run --with pytest pytest tests/test_ojs_journal_enrichment_contract.py -q`; extracted R `parse()`; `sh -n`; `git diff --check` | PASS: 3 tests, both QMD R programs, both shell entry points, and whitespace checks. |
+| Sample GREEN | `./render_sample.sh` with compatible source caches | PASS: the fixed ten-row path generated and validated the same wide-master contract in 29 seconds. |
+| Full master GREEN | `./render_full.sh` with all 1,031 OpenAlex batches and 169 Crossref pages reused | PASS after review fixes: the promoted CSV.gz contains 98,273 unique PKP identities and 80 columns, is about 95 MB compressed, preserves same-ISSN Crossref records, and passed post-write row, column, and identity checks. |
+| Difference-analysis GREEN | `research/ojs-journal-metadata/analysis/render_disagreement.sh` | PASS after review fixes: the offline QMD read the master, treated empty source values as missing evidence, reconciled all denominators, and atomically wrote a 98,273-row audit, summary CSV, three charts, and the fixed ten-row review under its own artifact subdirectory. |
+| Placement GREEN | The same disagreement render from `research/ojs-journal-metadata/analysis/` | PASS: enrichment and disagreement remain separate QMD pipelines owned by the same `ojs-journal-metadata` research directory. |
+| Repository regression | `uv run --with pytest --with pandas --with pyarrow pytest -q` | 23 passed. Seven failures were outside this owner: five arose from undeclared optional packages in the lightweight test environment and two were existing compendium/author-experience baseline failures. |
+
+### Simplification boundary
+
+The master expands the primary exact-ISSN candidate's 37 observed OpenAlex and
+11 observed Crossref top-level fields. Scalar values become ordinary cells and
+nested values remain JSON. Only genuinely ambiguous rows duplicate complete
+candidate sets as JSON: 221 OpenAlex rows and 439 Crossref rows. This avoids
+dynamic `candidate_2`, `candidate_3`, and later columns without discarding
+ambiguous source records.
+
+The final master has 439 Crossref multi-candidate rows after removing the
+incorrect ISSN-set deduplication. Crossref states reconcile to 52,591
+consistent, 439 inconsistent, 19,054 unmatched, and 26,189 not attempted.
+The corrected country comparison has 27,316 same, 2,668 different, and 24,169
+not-observed rows.
+
+The final cache-only render took about 40 minutes on the qualification machine;
+most time was spent serializing nested source fields. That is the accepted cost
+of the requested lossless wide master, not a reason to restore Parquet,
+pointer catalogs, a Python conversion layer, or analysis logic in the
+enrichment QMD.

--- a/research/ojs-journal-metadata/README.md
+++ b/research/ojs-journal-metadata/README.md
@@ -5,10 +5,17 @@ work here remains **Exploratory Analysis**.
 
 ## Question
 
-How consistently can exact ISSNs connect pinned PKP OJS records to OpenAlex
-Sources and Crossref journals, and what source-specific disagreements remain?
+How can exact ISSNs connect pinned PKP OJS records to OpenAlex Sources and
+Crossref journals in one reusable wide master without dropping source fields
+or PKP identities?
 
-## Reproduce the V7 Journal Enrichment
+## Referenced inputs
+
+- PKP Beacon V7 Dataverse file `14084919`
+- OpenAlex Sources
+- Crossref journals
+
+## Run
 
 The current explanatory notebook pins PKP V7 Dataverse file `14084919` at MD5
 `3a4ad8ae1ebfcc2b991aaf55b2d82c92`. It downloads the file when absent, checks
@@ -35,7 +42,7 @@ cd research/ojs-journal-metadata/analysis
 OPENALEX_API_KEY=... ./render_sample.sh
 ```
 
-The input, source caches, enriched artifact, run metadata, and rendered report stay
+The input, source caches, wide master, run metadata, and rendered report stay
 under `research/ojs-journal-metadata/artifacts/ojs_journal_enrichment/`, which
 is ignored. This command always runs sample mode; it cannot start a full-cohort
 retrieval.
@@ -58,39 +65,35 @@ page and `total-results` reconcile. `OPENALEX_API_KEY` and `CROSSREF_MAILTO`
 are required only when the corresponding cache/checkpoint is missing; they are
 never stored in generated artifacts.
 
-The qualified full run retrieves the complete Crossref directory in 169 pages.
-It writes one compact row for each PKP V7 row to
-`pkp-ojs-multisource-enriched.csv.gz`. Candidate identities resolve through
-`openalex-source-index.csv.gz` and `crossref-journal-index.csv.gz` to the
-complete RDS checkpoints. The QMD writes each table to a temporary compressed
-CSV, reads it back to verify its rows, schema, and PKP identities, and only then
-promotes it. There is no Parquet conversion layer, NDJSON staging, generated
-schema file, or duplicated validation manifest.
+The qualified full run retrieves the complete Crossref directory in 169 pages
+and writes one wide row for each PKP V7 row to
+`pkp-ojs-multisource-enriched.csv.gz`. Every observed top-level OpenAlex and
+Crossref field becomes a column. Nested values and multiple candidate records
+remain losslessly encoded as JSON cells. The QMD writes the CSV to a temporary
+file, reads it back to verify rows, columns, and PKP identities, and only then
+promotes it. RDS source caches and checkpoints are internal resumability
+artifacts, not additional data deliverables.
 
-On the qualified 98,273-row master, CSV.gz writes in about one second and reads
-in about one second or less. A dependency-free native R Parquet benchmark read
-faster but produced a file roughly three times larger, so CSV.gz remains the
-simpler qualified format at this scale. Reconsider native R Parquet if the
-cohort grows substantially or repeated column-selective reads become material;
-do not restore a Python conversion layer.
+The enrichment QMD stops after producing and checking that wide master. Run the
+complete exploratory difference analysis separately:
 
-Both commands also write
-`pkp-openalex-disagreement-audit.csv` in sample mode or the compressed
-`pkp-openalex-disagreement-audit.csv.gz` in full mode, plus
-`pkp-openalex-disagreement-summary.csv` in their mode-specific artifact
-directory. The full audit has one compact, traceable row per PKP V7 identity;
-the summary records each category's eligible denominator and includes the
-OpenAlex-by-Crossref status cross-tabulation. The report shows counts and
-percentages, three descriptive charts, and the fixed ten-row V7 review table.
-It omits long JSON from the table only: complete source records remain in the
-ignored checkpoints and resolve through the compact compressed CSV indexes.
+```bash
+cd research/ojs-journal-metadata/analysis
+./render_disagreement.sh
+```
+
+This offline analysis reads only the validated full master; it makes no API
+requests. It writes the row-level disagreement audit and category summary under
+`artifacts/ojs_journal_disagreement_analysis/`, and retains the title, ISSN,
+OJS, DOAJ, country, identity, and OpenAlex-by-Crossref comparisons with their
+eligible denominators and three descriptive charts.
 
 Delete generated reports, CSVs, or checkpoints when local storage is no longer
 needed; rerunning the same command recreates outputs and reuses only compatible
-versioned caches/checkpoints. Title, ISSN, OJS,
-DOAJ, and country differences are source-specific metadata evidence, not proof
-that either source is wrong. PKP country is inferred, absent DOAJ evidence is
-not a negative assertion, and all results remain **Exploratory Analysis**.
+versioned caches/checkpoints. Title, ISSN, OJS, DOAJ, and country differences
+are source-specific metadata evidence, not proof that either source is wrong.
+PKP country is inferred, absent DOAJ evidence is not a negative assertion, and
+all results remain **Exploratory Analysis**.
 
 ## PKP input decision
 

--- a/research/ojs-journal-metadata/analysis/ojs_journal_disagreement_analysis.qmd
+++ b/research/ojs-journal-metadata/analysis/ojs_journal_disagreement_analysis.qmd
@@ -1,0 +1,599 @@
+---
+title: "PKP–OpenAlex disagreement analysis"
+format: html
+execute:
+  echo: true
+  warning: true
+  message: false
+---
+
+This exploratory analysis reads the validated PKP V7 wide master produced by
+`ojs_journal_enrichment.qmd`. It compares source-specific evidence without
+treating either source as authoritative and without interpreting source absence
+as a causal measure of journal invisibility.
+
+## Load the wide master
+
+```{r}
+#| label: load-master
+
+required_packages <- c(
+  "countrycode",
+  "dplyr",
+  "ggplot2",
+  "jsonlite",
+  "purrr",
+  "readr",
+  "reactable",
+  "tibble"
+)
+missing_packages <- required_packages[
+  !vapply(required_packages, requireNamespace, logical(1), quietly = TRUE)
+]
+if (length(missing_packages)) {
+  stop(
+    paste("Install the documented R environment. Missing:",
+      paste(missing_packages, collapse = ", ")),
+    call. = FALSE
+  )
+}
+
+library(dplyr)
+library(ggplot2)
+library(purrr)
+library(readr)
+library(tibble)
+
+enrichment_artifact_dir <- file.path(
+  "..",
+  "artifacts",
+  "ojs_journal_enrichment"
+)
+master_path <- file.path(
+  enrichment_artifact_dir,
+  "full-v7",
+  "pkp-ojs-multisource-enriched.csv.gz"
+)
+analysis_dir <- file.path(
+  "..",
+  "artifacts",
+  "ojs_journal_disagreement_analysis"
+)
+audit_path <- file.path(
+  analysis_dir,
+  "pkp-openalex-disagreement-audit.csv.gz"
+)
+audit_summary_path <- file.path(
+  analysis_dir,
+  "pkp-openalex-disagreement-summary.csv"
+)
+dir.create(analysis_dir, recursive = TRUE, showWarnings = FALSE)
+
+if (!file.exists(master_path)) {
+  stop("Run render_full.sh before this analysis.", call. = FALSE)
+}
+master <- read_csv(
+  master_path,
+  col_types = cols(.default = col_character()),
+  na = character(),
+  show_col_types = FALSE
+)
+
+required_columns <- c(
+  "oai_url",
+  "repository_name",
+  "set_spec",
+  "context_name",
+  "issn",
+  "country",
+  "best_doaj_url",
+  "identifier_status",
+  "openalex_input_issns",
+  "openalex_matched_issns",
+  "openalex_match_status",
+  "openalex_candidate_count",
+  "openalex_candidate_ids",
+  "openalex_type",
+  "openalex_display_name",
+  "openalex_alternate_titles",
+  "openalex_issn",
+  "openalex_issn_l",
+  "openalex_is_ojs",
+  "openalex_is_in_doaj",
+  "openalex_country_code",
+  "crossref_match_status",
+  "crossref_candidate_count",
+  "crossref_candidate_issn_sets"
+)
+row_identity <- function(data) {
+  paste(data$oai_url, data$repository_name, data$set_spec, sep = "\r")
+}
+stopifnot(
+  nrow(master) == 98273L,
+  all(required_columns %in% names(master)),
+  !anyDuplicated(row_identity(master)),
+  !"admin_email" %in% names(master)
+)
+```
+
+## Classify identity and metadata differences
+
+Only rows with one exact-ISSN OpenAlex journal identity enter the metadata
+comparisons. Missing or ineligible evidence remains `not_observed`.
+
+```{r}
+#| label: classify-disagreements
+
+is_missing_value <- function(value) {
+  is.na(value) |
+    !nzchar(trimws(value)) |
+    toupper(trimws(value)) == "NA"
+}
+
+normalize_issn <- function(value) {
+  if (length(value) != 1L || is.na(value)) return(NA_character_)
+  compact <- gsub("[^0-9X]", "", toupper(trimws(as.character(value))))
+  if (!grepl("^[0-9]{7}[0-9X]$", compact)) return(NA_character_)
+
+  digits <- as.integer(strsplit(substr(compact, 1, 7), "")[[1]])
+  check_value <- (11 - sum(digits * 8:2) %% 11) %% 11
+  expected <- if (check_value == 10) "X" else as.character(check_value)
+  if (substr(compact, 8, 8) != expected) return(NA_character_)
+
+  paste0(substr(compact, 1, 4), "-", substr(compact, 5, 8))
+}
+
+json_values <- function(value) {
+  if (is_missing_value(value)) return(character())
+  parsed <- tryCatch(
+    jsonlite::fromJSON(value, simplifyVector = TRUE),
+    error = function(error) {
+      stop("Wide master contains invalid source JSON.", call. = FALSE)
+    }
+  )
+  as.character(unlist(parsed, use.names = FALSE))
+}
+
+pipe_values <- function(value) {
+  if (is_missing_value(value)) return(character())
+  strsplit(value, "|", fixed = TRUE)[[1]]
+}
+
+normalize_title <- function(value) {
+  if (is_missing_value(value)) return(NA_character_)
+  gsub("[[:punct:][:space:]]", "", tolower(enc2utf8(value)))
+}
+
+comparison_state <- function(left, right) {
+  if (is_missing_value(left) || is_missing_value(right)) {
+    return("not_observed")
+  }
+  if (identical(left, right)) "same" else "different"
+}
+stopifnot(
+  comparison_state("", "US") == "not_observed",
+  comparison_state("US", "") == "not_observed",
+  comparison_state("US", "US") == "same",
+  comparison_state("US", "GB") == "different"
+)
+
+category_summary <- function(
+  values,
+  categories,
+  dimension,
+  denominator_name
+) {
+  counts <- table(factor(values, levels = categories))
+  denominator <- length(values)
+  tibble(
+    dimension = dimension,
+    category = names(counts),
+    denominator_name = denominator_name,
+    denominator = denominator,
+    count = as.integer(counts),
+    percent = round(100 * count / denominator, 3)
+  )
+}
+
+candidate_count <- as.integer(master$openalex_candidate_count)
+input_issn_sets <- map_chr(master$openalex_input_issns, \(value) {
+  paste(sort(pipe_values(value)), collapse = "|")
+})
+matched_issn_sets <- map_chr(master$openalex_matched_issns, \(value) {
+  paste(sort(pipe_values(value)), collapse = "|")
+})
+openalex_source_issn_sets <- map2_chr(
+  master$openalex_issn,
+  master$openalex_issn_l,
+  \(issns, issn_l) {
+    values <- c(json_values(issns), issn_l)
+    normalized <- vapply(values, normalize_issn, character(1))
+    paste(sort(unique(normalized[!is.na(normalized)])), collapse = "|")
+  }
+)
+
+identity_outcome <- case_when(
+  master$identifier_status != "valid" ~ "no_valid_issn",
+  master$openalex_match_status == "api_error" ~ "api_error",
+  candidate_count == 0L ~ "valid_issn_unmatched",
+  candidate_count > 1L ~ "conflicting_source_ids",
+  is_missing_value(master$openalex_type) |
+    tolower(master$openalex_type) != "journal" ~ "non_journal_source",
+  input_issn_sets != matched_issn_sets ~ "partial_issn_agreement",
+  TRUE ~ "consistent"
+)
+identity_matched <- identity_outcome %in% c(
+  "consistent",
+  "partial_issn_agreement"
+)
+
+pkp_normalized_titles <- map_chr(master$context_name, normalize_title)
+openalex_normalized_titles <- map2(
+  master$openalex_display_name,
+  master$openalex_alternate_titles,
+  \(display_name, alternate_titles) {
+    titles <- c(display_name, json_values(alternate_titles))
+    normalized <- unique(na.omit(map_chr(titles, normalize_title)))
+    normalized[nzchar(normalized)]
+  }
+)
+title_comparison <- map2_chr(
+  pkp_normalized_titles,
+  openalex_normalized_titles,
+  \(pkp_title, openalex_titles) {
+    if (!length(openalex_titles) || is.na(pkp_title)) return("not_observed")
+    if (pkp_title %in% openalex_titles) "same" else "different"
+  }
+)
+title_comparison[!identity_matched] <- "not_observed"
+
+issn_set_comparison <- map2_chr(
+  input_issn_sets,
+  openalex_source_issn_sets,
+  comparison_state
+)
+issn_set_comparison[!identity_matched] <- "not_observed"
+
+ojs_evidence_comparison <- case_when(
+  !identity_matched | is_missing_value(master$openalex_is_ojs) ~ "not_observed",
+  master$openalex_is_ojs == "TRUE" ~ "same",
+  TRUE ~ "different"
+)
+
+pkp_doaj_evidence <- !is_missing_value(master$best_doaj_url)
+openalex_doaj_evidence <- master$openalex_is_in_doaj
+doaj_evidence_comparison <- case_when(
+  !identity_matched | is_missing_value(openalex_doaj_evidence) ~ "not_observed",
+  pkp_doaj_evidence & openalex_doaj_evidence == "TRUE" ~ "both_observed",
+  pkp_doaj_evidence ~ "pkp_only",
+  openalex_doaj_evidence == "TRUE" ~ "openalex_only",
+  TRUE ~ "neither_observed"
+)
+
+pkp_country_missing <- is_missing_value(master$country)
+pkp_country_code <- countrycode::countrycode(
+  master$country,
+  origin = "country.name",
+  destination = "iso2c",
+  warn = FALSE
+)
+openalex_country_code <- toupper(master$openalex_country_code)
+country_evidence_comparison <- map2_chr(
+  pkp_country_code,
+  openalex_country_code,
+  comparison_state
+)
+country_evidence_comparison[!identity_matched] <- "not_observed"
+
+audit <- master |>
+  transmute(
+    oai_url,
+    repository_name,
+    set_spec,
+    context_name,
+    issn,
+    identifier_status,
+    openalex_input_issns,
+    openalex_matched_issns,
+    openalex_match_status,
+    openalex_candidate_count,
+    openalex_candidate_ids,
+    crossref_match_status,
+    crossref_candidate_count,
+    crossref_candidate_issn_sets,
+    identity_outcome,
+    openalex_source_type = openalex_type,
+    openalex_display_name,
+    pkp_normalized_title = pkp_normalized_titles,
+    openalex_normalized_titles = map_chr(
+      openalex_normalized_titles,
+      paste,
+      collapse = "|"
+    ),
+    title_comparison,
+    pkp_issn_set = input_issn_sets,
+    openalex_issn_set = openalex_source_issn_sets,
+    issn_set_comparison,
+    ojs_evidence_comparison,
+    pkp_doaj_evidence,
+    openalex_doaj_evidence,
+    doaj_evidence_comparison,
+    pkp_country = country,
+    pkp_country_code,
+    openalex_country_code,
+    country_evidence_comparison
+  )
+```
+
+## Summarize and validate
+
+```{r}
+#| label: summarize-and-validate
+
+identity_categories <- c(
+  "consistent",
+  "partial_issn_agreement",
+  "conflicting_source_ids",
+  "non_journal_source",
+  "valid_issn_unmatched",
+  "no_valid_issn",
+  "api_error"
+)
+comparison_categories <- c("same", "different", "not_observed")
+status_categories <- c(
+  "consistent",
+  "inconsistent",
+  "unmatched",
+  "not_attempted",
+  "api_error"
+)
+matched_denominator <- sum(identity_matched)
+
+source_status_counts <- as_tibble(as.data.frame(table(
+  openalex = factor(
+    audit$openalex_match_status,
+    levels = status_categories
+  ),
+  crossref = factor(
+    audit$crossref_match_status,
+    levels = status_categories
+  )
+))) |>
+  transmute(
+    dimension = "source_status_crosstab",
+    category = paste0("openalex=", openalex, "|crossref=", crossref),
+    denominator_name = "all_pkp_v7_rows",
+    denominator = nrow(audit),
+    count = as.integer(Freq),
+    percent = round(100 * count / denominator, 3)
+  )
+
+metadata_disagreement_counts <- c(
+  normalized_title = sum(title_comparison == "different"),
+  issn_set = sum(issn_set_comparison == "different"),
+  ojs_evidence = sum(ojs_evidence_comparison == "different"),
+  doaj_evidence = sum(doaj_evidence_comparison %in% c(
+    "pkp_only",
+    "openalex_only"
+  )),
+  country_evidence = sum(country_evidence_comparison == "different")
+)
+metadata_disagreement_summary <- tibble(
+  dimension = "metadata_disagreement",
+  category = names(metadata_disagreement_counts),
+  denominator_name = "identity_matched_openalex_journals",
+  denominator = matched_denominator,
+  count = as.integer(metadata_disagreement_counts),
+  percent = round(100 * count / denominator, 3)
+)
+
+audit_summary <- bind_rows(
+  category_summary(
+    identity_outcome,
+    identity_categories,
+    "identity_outcome",
+    "all_pkp_v7_rows"
+  ),
+  category_summary(
+    title_comparison[identity_matched],
+    comparison_categories,
+    "normalized_title",
+    "identity_matched_openalex_journals"
+  ),
+  category_summary(
+    issn_set_comparison[identity_matched],
+    comparison_categories,
+    "issn_set",
+    "identity_matched_openalex_journals"
+  ),
+  category_summary(
+    ojs_evidence_comparison[identity_matched],
+    comparison_categories,
+    "ojs_evidence",
+    "identity_matched_openalex_journals"
+  ),
+  category_summary(
+    doaj_evidence_comparison[identity_matched],
+    c(
+      "both_observed",
+      "pkp_only",
+      "openalex_only",
+      "neither_observed",
+      "not_observed"
+    ),
+    "doaj_evidence",
+    "identity_matched_openalex_journals"
+  ),
+  category_summary(
+    country_evidence_comparison[identity_matched],
+    comparison_categories,
+    "country_evidence",
+    "identity_matched_openalex_journals"
+  ),
+  metadata_disagreement_summary,
+  source_status_counts
+)
+
+metadata_dimensions <- c(
+  "normalized_title",
+  "issn_set",
+  "ojs_evidence",
+  "doaj_evidence",
+  "country_evidence"
+)
+metadata_reconciliation <- audit_summary |>
+  filter(dimension %in% metadata_dimensions) |>
+  group_by(dimension) |>
+  summarise(
+    denominator = unique(denominator),
+    count = sum(count),
+    .groups = "drop"
+  )
+stopifnot(
+  nrow(audit) == nrow(master),
+  identical(audit$identity_outcome, identity_outcome),
+  sum(audit_summary$count[
+    audit_summary$dimension == "identity_outcome"
+  ]) == nrow(master),
+  nrow(metadata_reconciliation) == length(metadata_dimensions),
+  all(metadata_reconciliation$denominator == matched_denominator),
+  all(metadata_reconciliation$count == matched_denominator),
+  sum(audit_summary$count[
+    audit_summary$dimension == "source_status_crosstab"
+  ]) == nrow(master),
+  all(is.finite(audit_summary$percent))
+)
+
+write_csv_atomic <- function(data, path) {
+  temporary_path <- paste0(
+    path,
+    ".tmp",
+    if (endsWith(path, ".gz")) ".gz" else ""
+  )
+  unlink(temporary_path)
+  write_csv(data, temporary_path, na = "")
+  observed <- read_csv(
+    temporary_path,
+    col_types = cols(.default = col_character()),
+    na = character(),
+    show_col_types = FALSE
+  )
+  stopifnot(
+    nrow(observed) == nrow(data),
+    identical(names(observed), names(data))
+  )
+  if (!file.rename(temporary_path, path)) {
+    stop("Could not promote validated analysis output.", call. = FALSE)
+  }
+}
+write_csv_atomic(audit, audit_path)
+write_csv_atomic(audit_summary, audit_summary_path)
+stopifnot(file.exists(audit_path), file.exists(audit_summary_path))
+```
+
+## Identity outcomes
+
+These categories describe exact-ISSN identity evidence. They do not establish
+which source is correct and do not explain why a difference exists.
+
+```{r}
+#| label: identity-outcome-chart
+#| fig-width: 9
+#| fig-height: 5
+
+audit_summary |>
+  filter(dimension == "identity_outcome") |>
+  ggplot(aes(x = reorder(category, count), y = count)) +
+  geom_col() +
+  geom_text(
+    aes(label = sprintf("%s (%.2f%%)", count, percent)),
+    hjust = -0.05,
+    size = 3
+  ) +
+  coord_flip(clip = "off") +
+  scale_y_continuous(expand = expansion(mult = c(0, 0.18))) +
+  labs(x = NULL, y = "PKP V7 rows") +
+  theme_minimal()
+```
+
+## Metadata comparisons
+
+Title comparison uses the PKP title against the OpenAlex display name and
+alternate titles. PKP country is inferred metadata, not authoritative
+publisher location. Absent DOAJ evidence is not a negative assertion.
+
+```{r}
+#| label: metadata-disagreement-chart
+#| fig-width: 9
+#| fig-height: 4.5
+
+metadata_disagreement_summary |>
+  ggplot(aes(x = reorder(category, count), y = count)) +
+  geom_col() +
+  geom_text(
+    aes(label = sprintf("%s (%.2f%%)", count, percent)),
+    hjust = -0.05,
+    size = 3
+  ) +
+  coord_flip(clip = "off") +
+  scale_y_continuous(expand = expansion(mult = c(0, 0.18))) +
+  labs(x = NULL, y = "Identity-matched OpenAlex journals") +
+  theme_minimal()
+```
+
+## OpenAlex and Crossref match states
+
+```{r}
+#| label: source-status-heatmap
+#| fig-width: 9
+#| fig-height: 6
+
+audit_summary |>
+  filter(dimension == "source_status_crosstab") |>
+  mutate(
+    openalex = sub("\\|.*$", "", sub("^openalex=", "", category)),
+    crossref = sub("^.*\\|crossref=", "", category)
+  ) |>
+  ggplot(aes(x = openalex, y = crossref, fill = count)) +
+  geom_tile() +
+  geom_text(aes(label = sprintf("%s\n%.2f%%", count, percent)), size = 3) +
+  labs(x = "OpenAlex match state", y = "Crossref match state", fill = "Rows") +
+  theme_minimal()
+```
+
+## Purposive ten-row review
+
+```{r}
+#| label: disagreement-review
+
+sample_context_names <- c(
+  "Kuwait Journal of Science",
+  "Cakrawala",
+  "Sintesa: Jurnal Ilmu Pendidikan",
+  "CARAKA: Jurnal Teologi Biblika dan Praktika",
+  "Jurnal Tata Kelola dan Akuntabilitas Keuangan Negara",
+  "JOEEL (Journal of English Education and Literature)",
+  "Malaysian Journal of Paediatrics and Child Health",
+  "Jami Scientific Research Quarterly Journal",
+  "Journal of Polymer & Composites",
+  "JURNAL TEKNIK PERTAMBANGAN"
+)
+review_rows <- audit[
+  match(sample_context_names, audit$context_name),
+]
+stopifnot(!anyNA(review_rows$context_name))
+
+htmltools::div(
+  style = "overflow-x: auto;",
+  reactable::reactable(
+    review_rows,
+    searchable = TRUE,
+    filterable = TRUE,
+    pagination = TRUE,
+    defaultPageSize = 10,
+    resizable = TRUE,
+    compact = TRUE,
+    fullWidth = FALSE
+  )
+)
+```

--- a/research/ojs-journal-metadata/analysis/ojs_journal_disagreement_analysis.qmd
+++ b/research/ojs-journal-metadata/analysis/ojs_journal_disagreement_analysis.qmd
@@ -277,6 +277,7 @@ pkp_country_code <- countrycode::countrycode(
   destination = "iso2c",
   warn = FALSE
 )
+country_mapping_failures <- sum(!pkp_country_missing & is.na(pkp_country_code))
 openalex_country_code <- toupper(master$openalex_country_code)
 country_evidence_comparison <- map2_chr(
   pkp_country_code,
@@ -368,6 +369,15 @@ source_status_counts <- as_tibble(as.data.frame(table(
     percent = round(100 * count / denominator, 3)
   )
 
+country_mapping_summary <- tibble(
+  dimension = "country_mapping",
+  category = "unmapped_nonmissing",
+  denominator_name = "pkp_country_nonmissing_rows",
+  denominator = sum(!pkp_country_missing),
+  count = country_mapping_failures,
+  percent = round(100 * count / denominator, 3)
+)
+
 metadata_disagreement_counts <- c(
   normalized_title = sum(title_comparison == "different"),
   issn_set = sum(issn_set_comparison == "different"),
@@ -431,6 +441,7 @@ audit_summary <- bind_rows(
     "identity_matched_openalex_journals"
   ),
   metadata_disagreement_summary,
+  country_mapping_summary,
   source_status_counts
 )
 
@@ -566,22 +577,52 @@ audit_summary |>
 ```{r}
 #| label: disagreement-review
 
-sample_context_names <- c(
+sample_spec <- tribble(
+  ~context_name, ~oai_url, ~repository_name, ~set_spec,
   "Kuwait Journal of Science",
+  "https://journalskuwait.org/kjs/index.php/index/oai",
+  "Kuwait Journal of Science",
+  "KJS",
   "Cakrawala",
+  "https://cakrawalajournal.org/index.php/index/oai",
+  "CAKRAWALA",
+  "cakrawala",
   "Sintesa: Jurnal Ilmu Pendidikan",
+  "https://sintesa.stkip-arrahmaniyah.ac.id/index.php/index/oai",
+  "Sintesa: Jurnal Ilmu Pendidikan STKIP Arrahmaniyah Depok",
+  "sintesa",
   "CARAKA: Jurnal Teologi Biblika dan Praktika",
+  "https://ojs.sttibc.ac.id/index.php/index/oai",
+  "CARAKA:Jurnal Teologi",
+  "ibc",
   "Jurnal Tata Kelola dan Akuntabilitas Keuangan Negara",
+  "https://jurnal.bpk.go.id/index.php/index/oai",
+  "Open Journal Systems",
+  "TAKEN",
   "JOEEL (Journal of English Education and Literature)",
+  "https://journal.stkippamanetalino.ac.id/index.php/index/oai",
+  "Rumah Jurnal STKIP Pamane Talino Ngabang",
+  "bahasa-inggris",
   "Malaysian Journal of Paediatrics and Child Health",
+  "https://mpaeds.my/journals/index.php/index/oai",
+  "NA",
+  "MJPCH",
   "Jami Scientific Research Quarterly Journal",
+  "https://journals.jami.edu.af/index.php/index/oai",
+  "Jami University Press",
+  "jsrqj",
   "Journal of Polymer & Composites",
-  "JURNAL TEKNIK PERTAMBANGAN"
+  "https://engineeringjournals.stmjournals.in/index.php/index/oai",
+  "Engineering Journals",
+  "JoPC",
+  "JURNAL TEKNIK PERTAMBANGAN",
+  "https://e-journal.upr.ac.id/index.php/index/oai",
+  "Journal Online Universitas Palangka Raya",
+  "JTP"
 )
-review_rows <- audit[
-  match(sample_context_names, audit$context_name),
-]
-stopifnot(!anyNA(review_rows$context_name))
+sample_positions <- match(row_identity(sample_spec), row_identity(audit))
+stopifnot(!anyNA(sample_positions))
+review_rows <- audit[sample_positions, ]
 
 htmltools::div(
   style = "overflow-x: auto;",

--- a/research/ojs-journal-metadata/analysis/ojs_journal_enrichment.qmd
+++ b/research/ojs-journal-metadata/analysis/ojs_journal_enrichment.qmd
@@ -7,7 +7,7 @@ execute:
   message: false
 ---
 
-This notebook adds current OpenAlex Source and Crossref journal data to PKP OJS rows from the pinned V7 release by exact ISSN. Sample mode is the default. Full mode must be started with `render_full.sh`; it checkpoints both source directories and preserves all 98,273 PKP rows in a compact compressed CSV master.
+This notebook adds current OpenAlex Source and Crossref journal data to PKP OJS rows from the pinned V7 release by exact ISSN. Sample mode is the default. Full mode must be started with `render_full.sh`; it checkpoints both source directories and preserves all 98,273 PKP rows plus every returned top-level source field in one wide compressed CSV.
 
 Set `OPENALEX_API_KEY` before retrieving uncached OpenAlex data. Full mode also requires `CROSSREF_MAILTO` when a Crossref page is missing. A cache-only reproduction needs neither value. A normal render and `render_sample.sh` always use sample mode.
 
@@ -42,9 +42,7 @@ if (
 }
 
 required_packages <- c(
-  "countrycode",
   "dplyr",
-  "ggplot2",
   "httr2",
   "jsonlite",
   "knitr",
@@ -86,7 +84,6 @@ if (!identical(installed_package_versions, required_package_versions)) {
 }
 
 library(dplyr)
-library(ggplot2)
 library(httr2)
 library(purrr)
 library(readr)
@@ -123,20 +120,6 @@ output_path <- file.path(
   }
 )
 metadata_path <- file.path(run_dir, "run-metadata.json")
-audit_path <- file.path(
-  run_dir,
-  if (run_mode == "full") {
-    "pkp-openalex-disagreement-audit.csv.gz"
-  } else {
-    "pkp-openalex-disagreement-audit.csv"
-  }
-)
-audit_summary_path <- file.path(
-  run_dir,
-  "pkp-openalex-disagreement-summary.csv"
-)
-source_output_path <- file.path(run_dir, "openalex-source-index.csv.gz")
-crossref_output_path <- file.path(run_dir, "crossref-journal-index.csv.gz")
 openalex_cache_path <- file.path(run_dir, "openalex-sources.rds")
 crossref_cache_path <- file.path(run_dir, "crossref-journals.rds")
 openalex_batch_dir <- file.path(run_dir, "openalex-batches")
@@ -706,7 +689,7 @@ ojs_rows <- if (run_mode == "full") {
 
 ## Multi-source enrichment
 
-For each PKP row, the notebook looks for OpenAlex and Crossref records with the same checksum-valid normalized ISSN. If the same source identity appears more than once, it is counted once. Sample mode expands returned fields for review. Full mode keeps compact candidate identities in the one-row-per-PKP master and indexes both sources to complete checkpoint responses in companion compressed CSV files.
+For each PKP row, the notebook looks for OpenAlex and Crossref records with the same checksum-valid normalized ISSN. If the same source identity appears more than once, it is counted once. Both modes expand every returned top-level field into the one-row-per-PKP master and preserve nested values and complete candidate records as JSON cells.
 
 ### Sample matching helpers
 
@@ -729,132 +712,20 @@ crossref_key <- function(journal) {
   paste(sort(unique(issns[!is.na(issns)])), collapse = "|")
 }
 
-crossref_catalog_from_pages <- function(page_files) {
-  seen_keys <- new.env(hash = TRUE, parent = emptyenv())
-  catalog_pages <- vector("list", length(page_files))
-  source_fields <- character()
-
-  for (page_position in seq_along(page_files)) {
-    page_file <- page_files[[page_position]]
-    checkpoint <- readRDS(file.path(crossref_page_dir, page_file))
-    if (checkpoint$status != "complete") {
-      stop("Crossref catalog encountered an incomplete page.", call. = FALSE)
-    }
-    source_fields <- union(
-      source_fields,
-      unlist(map(checkpoint$items, names), use.names = FALSE)
-    )
-    page_rows <- imap(checkpoint$items, \(journal, record_index) {
-      candidate_key <- crossref_key(journal)
-      if (
-        !nzchar(candidate_key) ||
-          exists(candidate_key, seen_keys, inherits = FALSE)
-      ) {
-        return(NULL)
-      }
-      assign(candidate_key, TRUE, seen_keys)
-      tibble(
-        crossref_candidate_issn_set = candidate_key,
-        checkpoint_file = page_file,
-        record_index = as.character(record_index)
-      )
-    })
-    catalog_pages[[page_position]] <- bind_rows(compact(page_rows))
-  }
-
-  list(
-    rows = bind_rows(catalog_pages),
-    source_fields = sort(source_fields)
-  )
-}
-
-validate_crossref_catalog_pointers <- function(catalog, page_files) {
-  catalog_rows_by_page <- split(
-    seq_len(nrow(catalog)),
-    catalog$checkpoint_file
-  )
-  checkpoint_keys <- character()
+crossref_candidates_from_pages <- function(page_files) {
+  candidates <- list()
 
   for (page_file in page_files) {
     checkpoint <- readRDS(file.path(crossref_page_dir, page_file))
-    page_keys <- vapply(
-      checkpoint$items,
-      crossref_key,
-      character(1)
-    )
-    checkpoint_keys <- union(
-      checkpoint_keys,
-      page_keys[nzchar(page_keys)]
-    )
-
-    catalog_rows <- catalog_rows_by_page[[page_file]]
-    if (is.null(catalog_rows)) next
-    record_indices <- as.integer(catalog$record_index[catalog_rows])
-    if (
-      anyNA(record_indices) ||
-        any(record_indices < 1L | record_indices > length(page_keys))
-    ) {
-      stop(
-        "Crossref catalog contains an invalid record index.",
-        call. = FALSE
-      )
+    if (checkpoint$status != "complete") {
+      stop("Crossref enrichment encountered an incomplete page.", call. = FALSE)
     }
-    if (!identical(
-      unname(catalog$crossref_candidate_issn_set[catalog_rows]),
-      unname(page_keys[record_indices])
-    )) {
-      stop(
-        "Crossref catalog pointer does not resolve to its ISSN set.",
-        call. = FALSE
-      )
+    for (journal in checkpoint$items) {
+      candidates[[length(candidates) + 1L]] <- journal
     }
   }
 
-  if (!setequal(
-    catalog$crossref_candidate_issn_set,
-    checkpoint_keys
-  )) {
-    stop(
-      "Crossref catalog does not cover every checkpoint candidate.",
-      call. = FALSE
-    )
-  }
-  TRUE
-}
-
-index_crossref_catalog <- function(catalog) {
-  index <- new.env(hash = TRUE, parent = emptyenv())
-  for (candidate_key in catalog$crossref_candidate_issn_set) {
-    for (issn in strsplit(candidate_key, "|", fixed = TRUE)[[1]]) {
-      candidate_keys <- if (exists(issn, index, inherits = FALSE)) {
-        get(issn, index, inherits = FALSE)
-      } else {
-        character()
-      }
-      assign(issn, c(candidate_keys, candidate_key), index)
-    }
-  }
-  index
-}
-
-match_crossref_catalog <- function(input_issns, index) {
-  candidate_keys <- as.character(unique(unlist(map(input_issns, \(issn) {
-    if (exists(issn, index, inherits = FALSE)) {
-      get(issn, index, inherits = FALSE)
-    } else {
-      character()
-    }
-  }))))
-  candidate_issns <- unique(unlist(strsplit(
-    candidate_keys,
-    "|",
-    fixed = TRUE
-  )))
-  list(
-    status = classify_status(input_issns, candidate_keys),
-    matched_issns = intersect(input_issns, candidate_issns),
-    candidate_ids = candidate_keys
-  )
+  candidates
 }
 
 deduplicate_candidates <- function(candidates, identity) {
@@ -896,26 +767,34 @@ match_exact_issns <- function(
   input_issns,
   candidates,
   candidate_issns,
-  candidate_identity
+  candidate_identity,
+  deduplicate = TRUE
 ) {
   matched <- keep(candidates, \(candidate) {
     any(input_issns %in% candidate_issns(candidate))
   })
-  deduplicated <- deduplicate_candidates(matched, candidate_identity)
+  resolved <- if (deduplicate) {
+    deduplicate_candidates(matched, candidate_identity)
+  } else {
+    list(
+      candidates = matched,
+      candidate_ids = map_chr(matched, candidate_identity)
+    )
+  }
   matched_issns <- intersect(
     input_issns,
-    unique(unlist(map(deduplicated$candidates, candidate_issns)))
+    unique(unlist(map(resolved$candidates, candidate_issns)))
   )
 
   c(
     list(
       status = classify_status(
         input_issns,
-        deduplicated$candidate_ids
+        resolved$candidate_ids
       ),
       matched_issns = matched_issns
     ),
-    deduplicated
+    resolved
   )
 }
 
@@ -935,70 +814,37 @@ dataframe_value <- function(value) {
   serialize_json(value)
 }
 
-candidate_prefix <- function(prefix, index) {
-  if (index == 1L) prefix else paste0(prefix, "_candidate_", index)
-}
-
-expand_candidate_fields <- function(match, prefix) {
-  cells <- list()
-  for (index in seq_along(match$candidates)) {
-    candidate <- match$candidates[[index]]
-    values <- map(candidate, dataframe_value)
-    names(values) <- paste(
-      candidate_prefix(prefix, index),
-      names(candidate),
-      sep = "_"
-    )
-    cells <- c(cells, values)
-  }
-  cells[[paste0(prefix, "_candidates__json")]] <- serialize_json(
-    match$candidates
+expand_candidate_fields <- function(matches, prefix, fields) {
+  candidates <- map(
+    matches,
+    \(match) if (length(match$candidates)) match$candidates[[1]] else list()
+  )
+  cells <- set_names(
+    map(fields, \(field) {
+      map_chr(candidates, \(candidate) {
+        as.character(dataframe_value(candidate[[field]]))
+      })
+    }),
+    paste(prefix, fields, sep = "_")
+  )
+  cells[[paste0(prefix, "_candidates__json")]] <- map_chr(
+    matches,
+    \(match) {
+      if (length(match$candidates) > 1L) {
+        serialize_json(match$candidates)
+      } else {
+        NA_character_
+      }
+    }
   )
   as_tibble(cells, .name_repair = "check_unique")
 }
 
-normalize_title <- function(value) {
-  if (length(value) != 1L || is.na(value) || !nzchar(trimws(value))) {
-    return(NA_character_)
-  }
-  gsub("[[:punct:][:space:]]", "", tolower(enc2utf8(value)))
-}
-
-source_value <- function(source, field) {
-  value <- source[[field]]
-  if (is.null(value) || !length(value) || is.na(value[[1]])) {
-    return(NA_character_)
-  }
-  as.character(value[[1]])
-}
-
-comparison_state <- function(left, right) {
-  if (is.na(left) || is.na(right)) return("not_observed")
-  if (identical(left, right)) "same" else "different"
-}
-
-category_summary <- function(
-  values,
-  categories,
-  dimension,
-  denominator_name
-) {
-  counts <- table(factor(values, levels = categories))
-  denominator <- length(values)
-  tibble(
-    dimension = dimension,
-    category = names(counts),
-    denominator_name = denominator_name,
-    denominator = denominator,
-    count = as.integer(counts),
-    percent = round(100 * count / denominator, 3)
-  )
-}
 ```
 
 ### Enrichment orchestration
 
-Both modes use the same exact-ISSN rule. Full mode indexes candidates by normalized ISSN so matching 98,273 rows does not repeatedly scan either complete response set. Candidate identities connect the compact master to source catalogs and lossless checkpoints, so inconsistent identities remain complete without duplicating large JSON.
+Both modes use the same exact-ISSN rule. Full mode indexes candidates by normalized ISSN so matching 98,273 rows does not repeatedly scan either complete response set.
 
 ```{r}
 #| label: enrichment
@@ -1159,22 +1005,16 @@ base_result <- ojs_rows |>
   )
 ```
 
-### Crossref enrichment and review rows
+### Crossref enrichment and wide master
 
-Crossref is matched by the same normalized exact ISSNs. Full mode keeps compact
-candidate keys in the master and loads complete records only for the ten review
-rows.
+Crossref is matched by the same normalized exact ISSNs. Both modes write every
+returned top-level OpenAlex and Crossref field to the same one-row-per-PKP
+master. Nested and repeated values remain lossless JSON cells.
 
 ```{r}
 #| label: crossref-enrichment
 
 if (run_mode == "sample") {
-  openalex_data <- map_dfr(
-    openalex_matches,
-    expand_candidate_fields,
-    prefix = "openalex"
-  )
-  result <- bind_cols(base_result, openalex_data)
   crossref_cache <- if (file.exists(crossref_cache_path)) {
     tryCatch(readRDS(crossref_cache_path), error = \(error) NULL)
   } else {
@@ -1210,529 +1050,116 @@ if (run_mode == "sample") {
     journals
   }
   crossref_candidates <- unname(compact(crossref_journals))
-  crossref_index <- index_candidates_by_issn(
-    crossref_candidates,
-    \(journal) {
-      issns <- vapply(journal$ISSN, normalize_issn, character(1))
-      unique(issns[!is.na(issns)])
-    }
-  )
-  crossref_matches <- map(input_issns, \(issns) {
-    match_exact_issns(
-      issns,
-      candidates_for_issns(
-        crossref_candidates,
-        crossref_index,
-        issns
-      ),
-      \(journal) {
-        issns <- vapply(journal$ISSN, normalize_issn, character(1))
-        unique(issns[!is.na(issns)])
-      },
-      crossref_key
-    )
-  })
-  crossref_status_counts <- table(map_chr(crossref_matches, "status"))
-  crossref_data <- map_dfr(
-    crossref_matches,
-    expand_candidate_fields,
-    prefix = "crossref"
-  )
-  result <- result |>
-    mutate(
-      crossref_input_issns = map_chr(input_issns, paste, collapse = "|"),
-      crossref_matched_issns = map_chr(
-        crossref_matches,
-        \(match) paste(match$matched_issns, collapse = "|")
-      ),
-      crossref_match_status = map_chr(crossref_matches, "status"),
-      crossref_candidate_issn_sets = map_chr(
-        crossref_matches,
-        \(match) paste(match$candidate_ids, collapse = ";")
-      )
-    ) |>
-    bind_cols(crossref_data)
-  output_data <- result
-  output_rows <- nrow(result)
-  output_columns <- names(result)
-  review_result <- result
-  source_index <- NULL
 } else {
   crossref_directory <- fetch_crossref_directory()
-  crossref_catalog_contract <- crossref_catalog_from_pages(
+  crossref_candidates <- crossref_candidates_from_pages(
     crossref_directory$page_files
   )
-  crossref_catalog <- crossref_catalog_contract$rows
-  crossref_catalog_valid <- validate_crossref_catalog_pointers(
-    crossref_catalog,
-    crossref_directory$page_files
-  )
-  crossref_index <- index_crossref_catalog(crossref_catalog)
-  crossref_matches <- map(
-    input_issns,
-    match_crossref_catalog,
-    index = crossref_index
-  )
-  crossref_status_counts <- table(map_chr(crossref_matches, "status"))
-  base_result <- base_result |>
-    mutate(
-      crossref_input_issns = map_chr(input_issns, paste, collapse = "|"),
-      crossref_matched_issns = map_chr(
-        crossref_matches,
-        \(match) paste(match$matched_issns, collapse = "|")
-      ),
-      crossref_match_status = map_chr(crossref_matches, "status"),
-      crossref_candidate_count = map_int(
-        crossref_matches,
-        \(match) length(match$candidate_ids)
-      ),
-      crossref_candidate_issn_sets = map_chr(
-        crossref_matches,
-        \(match) paste(match$candidate_ids, collapse = ";")
-      )
-    )
+  crossref_cache_hit <- all(map_lgl(crossref_directory$pages, "reused"))
+}
 
-  openalex_fields <- sort(unique(unlist(map(openalex_sources, names))))
-  output_data <- base_result
-  output_rows <- nrow(base_result)
-  output_columns <- names(base_result)
-  checkpoint_by_source <- new.env(hash = TRUE, parent = emptyenv())
-  for (batch in batch_results) {
-    checkpoint_file <- sprintf("batch-%04d.rds", batch$batch_index)
-    for (source in batch$sources) {
-      if (!exists(source$id, checkpoint_by_source, inherits = FALSE)) {
-        assign(source$id, checkpoint_file, checkpoint_by_source)
-      }
-    }
-  }
-  source_ids <- map_chr(openalex_sources, "id")
-  source_index <- tibble(
-    openalex_source_id = source_ids,
-    checkpoint_file = unname(vapply(
-      source_ids,
-      get,
-      character(1),
-      envir = checkpoint_by_source,
-      inherits = FALSE
-    ))
-  )
-
-  crossref_page_cache <- new.env(hash = TRUE, parent = emptyenv())
-  load_crossref_candidates <- function(candidate_keys) {
-    map(candidate_keys, \(candidate_key) {
-      catalog_row <- match(
-        candidate_key,
-        crossref_catalog$crossref_candidate_issn_set
-      )
-      if (is.na(catalog_row)) {
-        stop("Crossref review candidate is missing from the index.", call. = FALSE)
-      }
-      page_file <- crossref_catalog$checkpoint_file[[catalog_row]]
-      if (!exists(page_file, crossref_page_cache, inherits = FALSE)) {
-        assign(
-          page_file,
-          readRDS(file.path(crossref_page_dir, page_file)),
-          crossref_page_cache
-        )
-      }
-      checkpoint <- get(page_file, crossref_page_cache, inherits = FALSE)
-      checkpoint$items[[as.integer(
-        crossref_catalog$record_index[[catalog_row]]
-      )]]
-    })
-  }
-  crossref_review_matches <- map(
-    crossref_matches[sample_positions],
-    \(match) c(
-      match,
-      list(candidates = load_crossref_candidates(match$candidate_ids))
-    )
-  )
-  review_result <- bind_cols(
-    base_result[sample_positions, ],
-    map_dfr(
-      openalex_matches[sample_positions],
-      expand_candidate_fields,
-      prefix = "openalex"
+crossref_issns <- function(journal) {
+  issns <- vapply(journal$ISSN, normalize_issn, character(1))
+  unique(issns[!is.na(issns)])
+}
+crossref_index <- index_candidates_by_issn(
+  crossref_candidates,
+  crossref_issns
+)
+crossref_matches <- map(input_issns, \(issns) {
+  match_exact_issns(
+    issns,
+    candidates_for_issns(
+      crossref_candidates,
+      crossref_index,
+      issns
     ),
-    map_dfr(
-      crossref_review_matches,
-      expand_candidate_fields,
-      prefix = "crossref"
-    )
+    crossref_issns,
+    crossref_key,
+    deduplicate = FALSE
   )
+})
+crossref_status_counts <- table(map_chr(crossref_matches, "status"))
+
+# ponytail: in-memory wide assembly fits V7; stream chunks if cohort growth
+# makes memory material.
+openalex_fields <- sort(unique(unlist(map(openalex_sources, names))))
+crossref_fields <- sort(unique(unlist(map(crossref_candidates, names))))
+openalex_data <- expand_candidate_fields(
+  openalex_matches,
+  prefix = "openalex",
+  fields = openalex_fields
+)
+crossref_data <- expand_candidate_fields(
+  crossref_matches,
+  prefix = "crossref",
+  fields = crossref_fields
+)
+result <- base_result |>
+  mutate(
+    crossref_input_issns = map_chr(input_issns, paste, collapse = "|"),
+    crossref_matched_issns = map_chr(
+      crossref_matches,
+      \(match) paste(match$matched_issns, collapse = "|")
+    ),
+    crossref_match_status = map_chr(crossref_matches, "status"),
+    crossref_candidate_count = map_int(
+      crossref_matches,
+      \(match) length(match$candidate_ids)
+    ),
+    crossref_candidate_issn_sets = map_chr(
+      crossref_matches,
+      \(match) paste(match$candidate_ids, collapse = ";")
+    )
+  ) |>
+  bind_cols(openalex_data, crossref_data)
+
+output_data <- result
+output_rows <- nrow(result)
+output_columns <- names(result)
+review_result <- if (run_mode == "full") {
+  result[sample_positions, ]
+} else {
+  result
 }
 ```
 
-### Disagreement audit
+### Validated master and provenance
 
-Identity outcomes are classified before title, ISSN-set, OJS, DOAJ, and country
-evidence are compared. Missing source evidence remains `not_observed`.
-
-```{r}
-#| label: disagreement-audit
-
-selected_openalex_sources <- map(openalex_matches, \(match) {
-  if (length(match$candidates) == 1L) match$candidates[[1]] else NULL
-})
-openalex_source_types <- map_chr(
-  selected_openalex_sources,
-  source_value,
-  field = "type"
-)
-openalex_source_issn_sets <- map_chr(selected_openalex_sources, \(source) {
-  paste(sort(source_issns(source)), collapse = "|")
-})
-input_issn_sets <- map_chr(input_issns, \(issns) {
-  paste(sort(issns), collapse = "|")
-})
-matched_issn_sets <- map_chr(openalex_matches, \(match) {
-  paste(sort(match$matched_issns), collapse = "|")
-})
-
-identity_outcome <- case_when(
-  base_result$identifier_status != "valid" ~ "no_valid_issn",
-  base_result$openalex_match_status == "api_error" ~ "api_error",
-  base_result$openalex_candidate_count == 0L ~ "valid_issn_unmatched",
-  base_result$openalex_candidate_count > 1L ~ "conflicting_source_ids",
-  is.na(openalex_source_types) |
-    tolower(openalex_source_types) != "journal" ~ "non_journal_source",
-  input_issn_sets != matched_issn_sets ~ "partial_issn_agreement",
-  TRUE ~ "consistent"
-)
-identity_matched <- identity_outcome %in% c(
-  "consistent",
-  "partial_issn_agreement"
-)
-
-pkp_normalized_titles <- map_chr(ojs_rows$context_name, normalize_title)
-openalex_normalized_titles <- map(selected_openalex_sources, \(source) {
-  titles <- c(
-    source_value(source, "display_name"),
-    unlist(source$alternate_titles, use.names = FALSE)
-  )
-  normalized <- unique(na.omit(map_chr(titles, normalize_title)))
-  normalized[nzchar(normalized)]
-})
-title_comparison <- map2_chr(
-  pkp_normalized_titles,
-  openalex_normalized_titles,
-  \(pkp_title, openalex_titles) {
-    if (!length(openalex_titles) || is.na(pkp_title)) return("not_observed")
-    if (pkp_title %in% openalex_titles) "same" else "different"
-  }
-)
-title_comparison[!identity_matched] <- "not_observed"
-
-issn_set_comparison <- map2_chr(
-  input_issn_sets,
-  openalex_source_issn_sets,
-  comparison_state
-)
-issn_set_comparison[!identity_matched] <- "not_observed"
-
-openalex_ojs_evidence <- map_chr(
-  selected_openalex_sources,
-  source_value,
-  field = "is_ojs"
-)
-ojs_evidence_comparison <- case_when(
-  !identity_matched | is.na(openalex_ojs_evidence) ~ "not_observed",
-  openalex_ojs_evidence == "TRUE" ~ "same",
-  TRUE ~ "different"
-)
-
-pkp_doaj_evidence <- !is_missing_value(ojs_rows$best_doaj_url)
-openalex_doaj_evidence <- map_chr(
-  selected_openalex_sources,
-  source_value,
-  field = "is_in_doaj"
-)
-doaj_evidence_comparison <- case_when(
-  !identity_matched | is.na(openalex_doaj_evidence) ~ "not_observed",
-  pkp_doaj_evidence & openalex_doaj_evidence == "TRUE" ~ "both_observed",
-  pkp_doaj_evidence ~ "pkp_only",
-  openalex_doaj_evidence == "TRUE" ~ "openalex_only",
-  TRUE ~ "neither_observed"
-)
-
-pkp_country_missing <- is_missing_value(ojs_rows$country)
-pkp_country_code <- countrycode::countrycode(
-  ojs_rows$country,
-  origin = "country.name",
-  destination = "iso2c",
-  warn = FALSE
-)
-country_mapping_failures <- sum(!pkp_country_missing & is.na(pkp_country_code))
-openalex_country_code <- toupper(map_chr(
-  selected_openalex_sources,
-  source_value,
-  field = "country_code"
-))
-country_evidence_comparison <- map2_chr(
-  pkp_country_code,
-  openalex_country_code,
-  comparison_state
-)
-country_evidence_comparison[!identity_matched] <- "not_observed"
-
-audit_base <- if (run_mode == "sample") result else base_result
-audit <- audit_base |>
-  transmute(
-    oai_url,
-    repository_name,
-    set_spec,
-    context_name,
-    issn,
-    identifier_status,
-    openalex_input_issns,
-    openalex_matched_issns,
-    openalex_match_status,
-    openalex_candidate_count,
-    openalex_candidate_ids,
-    crossref_match_status,
-    crossref_candidate_count = if ("crossref_candidate_count" %in% names(
-      audit_base
-    )) {
-      crossref_candidate_count
-    } else {
-      map_int(crossref_matches, \(match) length(match$candidate_ids))
-    },
-    crossref_candidate_issn_sets,
-    identity_outcome,
-    openalex_source_type = openalex_source_types,
-    openalex_display_name = map_chr(
-      selected_openalex_sources,
-      source_value,
-      field = "display_name"
-    ),
-    pkp_normalized_title = pkp_normalized_titles,
-    openalex_normalized_titles = map_chr(
-      openalex_normalized_titles,
-      paste,
-      collapse = "|"
-    ),
-    title_comparison,
-    pkp_issn_set = input_issn_sets,
-    openalex_issn_set = openalex_source_issn_sets,
-    issn_set_comparison,
-    ojs_evidence_comparison,
-    pkp_doaj_evidence,
-    openalex_doaj_evidence,
-    doaj_evidence_comparison,
-    pkp_country = country,
-    pkp_country_code,
-    openalex_country_code,
-    country_evidence_comparison
-  )
-
-identity_categories <- c(
-  "consistent",
-  "partial_issn_agreement",
-  "conflicting_source_ids",
-  "non_journal_source",
-  "valid_issn_unmatched",
-  "no_valid_issn",
-  "api_error"
-)
-comparison_categories <- c("same", "different", "not_observed")
-matched_denominator <- sum(identity_matched)
-status_categories <- c(
-  "consistent",
-  "inconsistent",
-  "unmatched",
-  "not_attempted",
-  "api_error"
-)
-source_status_counts <- as_tibble(as.data.frame(table(
-  openalex = factor(
-    audit$openalex_match_status,
-    levels = status_categories
-  ),
-  crossref = factor(
-    audit$crossref_match_status,
-    levels = status_categories
-  )
-))) |>
-  transmute(
-    dimension = "source_status_crosstab",
-    category = paste0("openalex=", openalex, "|crossref=", crossref),
-    denominator_name = "all_pkp_v7_rows",
-    denominator = nrow(audit),
-    count = as.integer(Freq),
-    percent = round(100 * count / denominator, 3)
-  )
-metadata_disagreement_counts <- c(
-  normalized_title = sum(title_comparison == "different"),
-  issn_set = sum(issn_set_comparison == "different"),
-  ojs_evidence = sum(ojs_evidence_comparison == "different"),
-  doaj_evidence = sum(doaj_evidence_comparison %in% c(
-    "pkp_only",
-    "openalex_only"
-  )),
-  country_evidence = sum(country_evidence_comparison == "different")
-)
-metadata_disagreement_summary <- tibble(
-  dimension = "metadata_disagreement",
-  category = names(metadata_disagreement_counts),
-  denominator_name = "identity_matched_openalex_journals",
-  denominator = matched_denominator,
-  count = as.integer(metadata_disagreement_counts),
-  percent = round(100 * count / denominator, 3)
-)
-audit_summary <- bind_rows(
-  category_summary(
-    identity_outcome,
-    identity_categories,
-    "identity_outcome",
-    "all_pkp_v7_rows"
-  ),
-  category_summary(
-    title_comparison[identity_matched],
-    comparison_categories,
-    "normalized_title",
-    "identity_matched_openalex_journals"
-  ),
-  category_summary(
-    issn_set_comparison[identity_matched],
-    comparison_categories,
-    "issn_set",
-    "identity_matched_openalex_journals"
-  ),
-  category_summary(
-    ojs_evidence_comparison[identity_matched],
-    comparison_categories,
-    "ojs_evidence",
-    "identity_matched_openalex_journals"
-  ),
-  category_summary(
-    doaj_evidence_comparison[identity_matched],
-    c(
-      "both_observed",
-      "pkp_only",
-      "openalex_only",
-      "neither_observed",
-      "not_observed"
-    ),
-    "doaj_evidence",
-    "identity_matched_openalex_journals"
-  ),
-  category_summary(
-    country_evidence_comparison[identity_matched],
-    comparison_categories,
-    "country_evidence",
-    "identity_matched_openalex_journals"
-  ),
-  metadata_disagreement_summary,
-  source_status_counts
-)
-```
-
-### Validated artifacts and provenance
-
-Each table is written to a temporary file, read back, and promoted only after
-its schema, row count, and PKP identities pass.
+The wide master is written to a temporary file, read back, and promoted only
+after its schema, row count, and PKP identities pass.
 
 ```{r}
-#| label: validated-artifacts
+#| label: validated-master
 
-artifact_tables <- list(
-  master = output_data,
-  audit = audit,
-  summary = audit_summary
+temporary_output_path <- paste0(
+  output_path,
+  ".tmp",
+  if (endsWith(output_path, ".gz")) ".gz" else ""
 )
-artifact_paths <- c(
-  master = output_path,
-  audit = audit_path,
-  summary = audit_summary_path
+unlink(temporary_output_path)
+write_csv(output_data, temporary_output_path, na = "")
+
+observed_output <- read_csv(
+  temporary_output_path,
+  col_types = cols(.default = col_character()),
+  na = character(),
+  show_col_types = FALSE
 )
-if (run_mode == "full") {
-  artifact_tables$openalex_index <- source_index
-  artifact_tables$crossref_index <- crossref_catalog
-  artifact_paths <- c(
-    artifact_paths,
-    openalex_index = source_output_path,
-    crossref_index = crossref_output_path
-  )
+observed_identity <- row_identity(observed_output)
+stopifnot(
+  nrow(observed_output) == nrow(output_data),
+  identical(names(observed_output), names(output_data)),
+  identical(observed_identity, row_identity(ojs_rows)),
+  !anyDuplicated(observed_identity)
+)
+if (!file.rename(temporary_output_path, output_path)) {
+  stop("Could not promote the validated wide master.", call. = FALSE)
 }
-
-temporary_csv_path <- function(path) {
-  paste0(path, ".tmp", if (endsWith(path, ".gz")) ".gz" else "")
-}
-temporary_paths <- map_chr(artifact_paths, temporary_csv_path)
-walk2(artifact_tables, temporary_paths, \(data, path) {
-  unlink(path)
-  write_csv(data, path, na = "")
-})
-
-artifact_validation <- imap(artifact_tables, \(expected, name) {
-  observed <- read_csv(
-    temporary_paths[[name]],
-    col_types = cols(.default = col_character()),
-    na = character(),
-    show_col_types = FALSE
-  )
-  expected_text <- mutate(
-    expected,
-    across(everything(), \(value) {
-      value <- as.character(value)
-      replace(value, is.na(value), "")
-    })
-  )
-  semantic_columns <- switch(
-    name,
-    master = c(
-      "oai_url",
-      "repository_name",
-      "set_spec",
-      "identifier_status",
-      "openalex_match_status",
-      "openalex_candidate_ids",
-      "crossref_match_status",
-      "crossref_candidate_issn_sets"
-    ),
-    audit = c(
-      "oai_url",
-      "repository_name",
-      "set_spec",
-      "identity_outcome",
-      "title_comparison",
-      "issn_set_comparison",
-      "ojs_evidence_comparison",
-      "doaj_evidence_comparison",
-      "country_evidence_comparison"
-    ),
-    summary = c(
-      "dimension",
-      "category",
-      "denominator_name",
-      "denominator",
-      "count"
-    ),
-    openalex_index = names(expected),
-    crossref_index = names(expected)
-  )
-  values_match <- map2_lgl(
-    observed[semantic_columns],
-    expected_text[semantic_columns],
-    \(left, right) isTRUE(all.equal(
-      left,
-      right,
-      check.attributes = FALSE
-    ))
-  )
-  stopifnot(
-    nrow(observed) == nrow(expected),
-    identical(names(observed), names(expected)),
-    all(values_match)
-  )
-  list(rows = nrow(observed), columns = ncol(observed))
-})
-walk2(temporary_paths, artifact_paths, \(temporary, final) {
-  if (!file.rename(temporary, final)) {
-    stop(paste("Could not promote validated artifact:", basename(final)))
-  }
-})
+artifact_validation <- list(
+  rows = nrow(observed_output),
+  columns = ncol(observed_output)
+)
 
 openalex_retrieval_times <- if (run_mode == "full") {
   unlist(map(batch_results, \(batch) map_chr(batch$pages, "retrieved_at")))
@@ -1764,48 +1191,15 @@ run_metadata <- list(
     format = if (run_mode == "full") "csv.gz" else "csv",
     rows = output_rows,
     columns = length(output_columns),
+    retained_top_level_fields = list(
+      openalex = openalex_fields,
+      crossref = crossref_fields
+    ),
     status_counts = list(
       openalex = as.list(openalex_status_counts),
       crossref = as.list(crossref_status_counts)
     )
   ),
-  disagreement_audit = list(
-    file = basename(audit_path),
-    md5 = unname(tools::md5sum(audit_path)),
-    rows = nrow(audit),
-    columns = ncol(audit),
-    summary_file = basename(audit_summary_path),
-    summary_md5 = unname(tools::md5sum(audit_summary_path)),
-    summary_rows = nrow(audit_summary),
-    identity_matched_rows = matched_denominator
-  ),
-  country_mapping = list(
-    nonmissing_input_rows = sum(!pkp_country_missing),
-    unmapped_nonmissing_rows = country_mapping_failures
-  ),
-  openalex_index = if (run_mode == "full") {
-    list(
-      file = basename(source_output_path),
-      md5 = unname(tools::md5sum(source_output_path)),
-      rows = artifact_validation$openalex_index$rows,
-      columns = artifact_validation$openalex_index$columns,
-      retained_top_level_fields = openalex_fields
-    )
-  } else {
-    NULL
-  },
-  crossref_index = if (run_mode == "full") {
-    list(
-      file = basename(crossref_output_path),
-      md5 = unname(tools::md5sum(crossref_output_path)),
-      rows = artifact_validation$crossref_index$rows,
-      columns = artifact_validation$crossref_index$columns,
-      retained_top_level_fields =
-        crossref_catalog_contract$source_fields
-    )
-  } else {
-    NULL
-  },
   retrieval = if (run_mode == "full") {
     list(
       openalex = list(
@@ -1846,10 +1240,7 @@ run_metadata <- list(
       completed_pages = sum(
         map_chr(crossref_directory$pages, "status") == "complete"
       ),
-      reused_pages = sum(map_lgl(
-        crossref_directory$pages,
-        "reused"
-      )),
+      reused_pages = sum(map_lgl(crossref_directory$pages, "reused")),
       attempts = sum(map_int(crossref_directory$pages, "attempts")),
       failed_pages = sum(
         map_chr(crossref_directory$pages, "status") != "complete"
@@ -1881,16 +1272,17 @@ if (!file.rename(metadata_temporary_path, metadata_path)) {
 }
 ```
 
+
 ## Checks
 
-These checks confirm that every input row appears in the master, every returned top-level API field remains in the lossless source checkpoints, both catalogs reconcile, credentials stay private, and full-mode pagination completed without unresolved API failures.
+These checks confirm that the wide master preserves every input identity, every
+returned top-level source field, explicit match states, and no private values.
 
 ```{r}
 #| label: contract-check
 
 metadata_text <- paste(readLines(metadata_path, warn = FALSE), collapse = "\n")
 artifact_root <- normalizePath(artifact_dir)
-artifact_columns <- tolower(unlist(map(artifact_tables, names)))
 private_values <- c(Sys.getenv("OPENALEX_API_KEY"), crossref_mailto)
 private_values <- private_values[nzchar(private_values)]
 metadata_contains_private_value <- any(vapply(
@@ -1898,80 +1290,54 @@ metadata_contains_private_value <- any(vapply(
   \(value) grepl(value, metadata_text, fixed = TRUE),
   logical(1)
 ))
-metadata_dimensions <- c(
-  "normalized_title",
-  "issn_set",
-  "ojs_evidence",
-  "doaj_evidence",
-  "country_evidence"
-)
-metadata_reconciliation <- audit_summary |>
-  filter(dimension %in% metadata_dimensions) |>
-  group_by(dimension) |>
-  summarise(
-    denominator = unique(denominator),
-    count = sum(count),
-    .groups = "drop"
+has_source_field <- function(prefix, field) {
+  any(
+    startsWith(output_columns, paste0(prefix, "_")) &
+      endsWith(output_columns, paste0("_", field))
   )
+}
 
 stopifnot(
+  identical(pkp_version, 7L),
+  is.na(normalize_issn(NULL)),
+  identical(unname(tools::md5sum(input_path)), pkp_md5),
+  nrow(raw_input) == 98273L,
+  identical(names(raw_input), expected_schema),
+  !anyDuplicated(raw_row_identity),
+  sum(missing_identifier) == 26189L,
+  sum(lengths(all_input_issns) > 0L) == 72084L,
+  length(unique(unlist(all_input_issns))) == 103017L,
   startsWith(normalizePath(input_path), artifact_root),
   startsWith(normalizePath(output_path), artifact_root),
   startsWith(normalizePath(metadata_path), artifact_root),
-  startsWith(normalizePath(audit_path), artifact_root),
-  startsWith(normalizePath(audit_summary_path), artifact_root),
+  file.exists(output_path),
   file.exists(metadata_path),
-  file.exists(audit_path),
-  file.exists(audit_summary_path),
   !grepl("OPENALEX_API_KEY|CROSSREF_MAILTO", metadata_text),
   !metadata_contains_private_value,
-  !any(c("admin_email", "openalex_api_key", "crossref_mailto") %in%
-    artifact_columns),
+  !"admin_email" %in% output_columns,
   all(nzchar(unlist(run_metadata$runtime))),
   output_rows == nrow(ojs_rows),
-  file.exists(output_path),
+  identical(output_columns, names(observed_output)),
   all(c(
     "openalex_match_status",
     "openalex_candidate_count",
-    "openalex_candidate_ids"
+    "openalex_candidate_ids",
+    "openalex_candidates__json",
+    "crossref_match_status",
+    "crossref_candidate_count",
+    "crossref_candidate_issn_sets",
+    "crossref_candidates__json"
   ) %in% output_columns),
-  identical(
-    base_result$openalex_candidate_count,
-    map_int(openalex_matches, \(match) length(match$candidate_ids))
-  ),
-  all(base_result$openalex_match_status %in% c(
-    "consistent",
-    "inconsistent",
-    "unmatched",
-    "not_attempted",
-    "api_error"
-  )),
+  all(map_lgl(openalex_fields, \(field) {
+    has_source_field("openalex", field)
+  })),
+  all(map_lgl(crossref_fields, \(field) {
+    has_source_field("crossref", field)
+  })),
   sum(unlist(run_metadata$output$status_counts$openalex)) == output_rows,
   sum(unlist(run_metadata$output$status_counts$crossref)) == output_rows,
-  nrow(audit) == output_rows,
-  identical(audit$identity_outcome, identity_outcome),
-  identical(
-    pkp_doaj_evidence,
-    !is_missing_value(ojs_rows$best_doaj_url)
-  ),
-  setequal(
-    audit_summary$category[audit_summary$dimension == "identity_outcome"],
-    identity_categories
-  ),
-  sum(audit_summary$count[
-    audit_summary$dimension == "identity_outcome"
-  ]) == output_rows,
-  nrow(metadata_reconciliation) == length(metadata_dimensions),
-  all(metadata_reconciliation$denominator == matched_denominator),
-  all(metadata_reconciliation$count == matched_denominator),
-  sum(audit_summary$count[
-    audit_summary$dimension == "source_status_crosstab"
-  ]) == output_rows,
-  all(audit_summary$denominator[
-    audit_summary$dimension == "source_status_crosstab"
-  ] == output_rows),
-  !"admin_email" %in% names(audit),
-  all(is.finite(audit_summary$percent))
+  artifact_validation$rows == output_rows,
+  artifact_validation$columns == length(output_columns)
 )
 
 if (run_mode == "sample") {
@@ -1987,36 +1353,11 @@ if (run_mode == "sample") {
     "not_attempted",
     "inconsistent"
   )
-  expected_identity_outcome <- c(
-    "consistent",
-    "consistent",
-    "valid_issn_unmatched",
-    "consistent",
-    "consistent",
-    "consistent",
-    "consistent",
-    "partial_issn_agreement",
-    "no_valid_issn",
-    "conflicting_source_ids"
-  )
   stopifnot(
     identical(row_identity(ojs_rows), sample_identity),
     sum(result$identifier_status == "missing") == 1L,
     nrow(result) == 10L,
-    all(c(
-      "openalex_id",
-      "openalex_summary_stats",
-      "openalex_topics",
-      "openalex_candidates__json",
-      "openalex_candidate_2_id",
-      "crossref_match_status",
-      "crossref_title",
-      "crossref_counts",
-      "crossref_coverage",
-      "crossref_candidates__json"
-    ) %in% names(result)),
     identical(result$openalex_match_status, expected_openalex_status),
-    identical(identity_outcome, expected_identity_outcome),
     result$openalex_matched_issns[
       result$context_name == "Jami Scientific Research Quarterly Journal"
     ] == "2710-4990",
@@ -2039,8 +1380,7 @@ if (run_mode == "sample") {
     })),
     run_metadata$openalex$completed_batches == length(token_batches),
     run_metadata$openalex$failed_batches == 0L,
-    !any(base_result$openalex_match_status == "api_error"),
-    !any(identity_outcome == "api_error"),
+    !any(result$openalex_match_status == "api_error"),
     all(nzchar(unlist(run_metadata$retrieval))),
     identical(crossref_directory$status, "complete"),
     identical(crossref_directory$rows_per_page, 1000L),
@@ -2055,126 +1395,24 @@ if (run_mode == "sample") {
     run_metadata$crossref$completed_pages ==
       length(crossref_directory$pages),
     run_metadata$crossref$failed_pages == 0L,
-    all(base_result$crossref_match_status %in% c(
+    all(result$crossref_match_status %in% c(
       "consistent",
       "inconsistent",
       "unmatched",
       "not_attempted"
     )),
-    !any(base_result$crossref_match_status == "api_error"),
     endsWith(output_path, ".csv.gz"),
-    all(c(
-      "openalex_display_name",
-      "crossref_title"
-    ) %in% names(review_result)),
-    identical(run_metadata$output$format, "csv.gz"),
-    artifact_validation$master$rows == output_rows,
-    artifact_validation$master$columns == length(output_columns),
-    artifact_validation$openalex_index$rows == length(openalex_sources),
-    artifact_validation$crossref_index$rows == nrow(crossref_catalog),
-    isTRUE(crossref_catalog_valid),
-    !anyDuplicated(source_index$openalex_source_id),
-    !anyDuplicated(crossref_catalog$crossref_candidate_issn_set),
-    all(unique(unlist(map(openalex_matches, "candidate_ids"))) %in%
-      map_chr(openalex_sources, "id")),
-    all(unique(unlist(map(crossref_matches, "candidate_ids"))) %in%
-      crossref_catalog$crossref_candidate_issn_set),
-    file.exists(source_output_path),
-    file.exists(crossref_output_path),
-    all(file.exists(file.path(
-      openalex_batch_dir,
-      source_index$checkpoint_file
-    ))),
-    all(file.exists(file.path(
-      crossref_page_dir,
-      crossref_catalog$checkpoint_file
-    )))
+    identical(run_metadata$output$format, "csv.gz")
   )
 }
 ```
 
-## Identity outcomes
-
-These categories describe exact-ISSN identity evidence. They do not establish
-which source is correct and do not explain why a difference exists.
-
-```{r}
-#| label: identity-outcome-chart
-#| fig-width: 9
-#| fig-height: 5
-
-audit_summary |>
-  filter(dimension == "identity_outcome") |>
-  ggplot(aes(x = reorder(category, count), y = count)) +
-  geom_col() +
-  geom_text(
-    aes(label = sprintf("%s (%.2f%%)", count, percent)),
-    hjust = -0.05,
-    size = 3
-  ) +
-  coord_flip(clip = "off") +
-  scale_y_continuous(expand = expansion(mult = c(0, 0.18))) +
-  labs(x = NULL, y = "PKP V7 rows") +
-  theme_minimal()
-```
-
-## Metadata comparisons
-
-Metadata comparisons are limited to PKP rows with one exact-ISSN OpenAlex
-journal identity. Title comparison uses normalized PKP titles against both the
-OpenAlex display name and alternate titles. PKP country is inferred metadata,
-not authoritative publisher location. PKP and OpenAlex DOAJ fields are
-source-specific positive evidence; absence is not proof that a journal is not
-in DOAJ.
-
-```{r}
-#| label: metadata-disagreement-chart
-#| fig-width: 9
-#| fig-height: 4.5
-
-metadata_disagreement_summary |>
-  ggplot(aes(x = reorder(category, count), y = count)) +
-  geom_col() +
-  geom_text(
-    aes(label = sprintf("%s (%.2f%%)", count, percent)),
-    hjust = -0.05,
-    size = 3
-  ) +
-  coord_flip(clip = "off") +
-  scale_y_continuous(expand = expansion(mult = c(0, 0.18))) +
-  labs(x = NULL, y = "Identity-matched OpenAlex journals") +
-  theme_minimal()
-```
-
-## OpenAlex and Crossref match states
-
-Source absence remains a source-specific `unmatched` or `not_attempted` state;
-it is not collapsed into a generic metadata failure.
-
-```{r}
-#| label: source-status-heatmap
-#| fig-width: 9
-#| fig-height: 6
-
-audit_summary |>
-  filter(dimension == "source_status_crosstab") |>
-  mutate(
-    openalex = sub("\\|.*$", "", sub("^openalex=", "", category)),
-    crossref = sub("^.*\\|crossref=", "", category)
-  ) |>
-  ggplot(aes(x = openalex, y = crossref, fill = count)) +
-  geom_tile() +
-  geom_text(aes(label = sprintf("%s\n%.2f%%", count, percent)), size = 3) +
-  labs(x = "OpenAlex match state", y = "Crossref match state", fill = "Rows") +
-  theme_minimal()
-```
 
 ## Purposive ten-row review
 
 This searchable, filterable table uses the fixed V7 sample in its deliberate
-display order. It includes every compact master field and omits only columns
-whose values are long JSON; complete OpenAlex and Crossref objects remain
-available through the source catalogs and checkpoint pointers.
+display order. It includes every master field and omits only columns whose
+values are long JSON; those values remain complete in the wide master.
 
 ```{r}
 #| label: interactive-sample-dataframe
@@ -2212,8 +1450,7 @@ htmltools::div(
 
 ## Complete merged column list
 
-This table lists every column in the compact master artifact. Long source
-objects live in checkpoints instead of being duplicated across PKP rows.
+This table lists every column in the wide master artifact.
 
 ```{r}
 #| label: complete-column-list

--- a/research/ojs-journal-metadata/analysis/render_disagreement.sh
+++ b/research/ojs-journal-metadata/analysis/render_disagreement.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+analysis_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+enrichment_artifact_dir="$analysis_dir/../artifacts/ojs_journal_enrichment"
+artifact_dir="$analysis_dir/../artifacts/ojs_journal_disagreement_analysis"
+render_source_dir="$artifact_dir/render-source"
+export R_LIBS_USER="$enrichment_artifact_dir/renv-library"
+
+test -d "$R_LIBS_USER" || {
+  echo "Restore the enrichment R environment before this analysis." >&2
+  exit 1
+}
+mkdir -p "$render_source_dir"
+cp "$analysis_dir/ojs_journal_disagreement_analysis.qmd" "$render_source_dir/"
+cd "$render_source_dir"
+quarto render ojs_journal_disagreement_analysis.qmd \
+  --execute-dir "$analysis_dir" \
+  --output-dir ../rendered
+
+audit="$artifact_dir/pkp-openalex-disagreement-audit.csv.gz"
+summary="$artifact_dir/pkp-openalex-disagreement-summary.csv"
+test -f "$audit"
+test -f "$summary"
+gzip -t "$audit"
+grep -q '^dimension,category,denominator_name,denominator,count,percent$' "$summary"
+grep -q '^identity_outcome,consistent,all_pkp_v7_rows,98273,' "$summary"
+grep -q '^source_status_crosstab,openalex=' "$summary"

--- a/research/ojs-journal-metadata/analysis/render_full.sh
+++ b/research/ojs-journal-metadata/analysis/render_full.sh
@@ -15,23 +15,9 @@ OJS_ENRICHMENT_MODE=full quarto render ojs_journal_enrichment.qmd \
 
 test -f "$artifact_dir/full-v7/run-metadata.json"
 test -f "$artifact_dir/full-v7/pkp-ojs-multisource-enriched.csv.gz"
-test -f "$artifact_dir/full-v7/openalex-source-index.csv.gz"
-test -f "$artifact_dir/full-v7/crossref-journal-index.csv.gz"
-test -f "$artifact_dir/full-v7/pkp-openalex-disagreement-audit.csv.gz"
-test -f "$artifact_dir/full-v7/pkp-openalex-disagreement-summary.csv"
 gzip -t "$artifact_dir/full-v7/pkp-ojs-multisource-enriched.csv.gz"
-gzip -t "$artifact_dir/full-v7/openalex-source-index.csv.gz"
-gzip -t "$artifact_dir/full-v7/crossref-journal-index.csv.gz"
-gzip -t "$artifact_dir/full-v7/pkp-openalex-disagreement-audit.csv.gz"
 grep -q '"run_mode": "full"' "$artifact_dir/full-v7/run-metadata.json"
 grep -q '"rows": 98273' "$artifact_dir/full-v7/run-metadata.json"
 grep -q '"format": "csv.gz"' "$artifact_dir/full-v7/run-metadata.json"
 grep -q '"rows_per_page": 1000' "$artifact_dir/full-v7/run-metadata.json"
 grep -q '"failed_pages": 0' "$artifact_dir/full-v7/run-metadata.json"
-grep -q '"disagreement_audit"' "$artifact_dir/full-v7/run-metadata.json"
-grep -q '^dimension,category,denominator_name,denominator,count,percent$' \
-  "$artifact_dir/full-v7/pkp-openalex-disagreement-summary.csv"
-grep -q '^identity_outcome,consistent,all_pkp_v7_rows,98273,' \
-  "$artifact_dir/full-v7/pkp-openalex-disagreement-summary.csv"
-grep -q '^source_status_crosstab,openalex=' \
-  "$artifact_dir/full-v7/pkp-openalex-disagreement-summary.csv"

--- a/tests/test_exploratory_owners.py
+++ b/tests/test_exploratory_owners.py
@@ -24,6 +24,7 @@ OWNER_NOTEBOOKS = {
         "csv_parquet_semantic_parity_validation.ipynb",
         "openalex_by_year_to_parquet.ipynb",
     },
+    "ojs-journal-metadata": set(),
     "scimago-openalex-coverage": {
         "merge_sjr_communication_1999_2024.ipynb",
         "scim_openalex_coverage_1999_2024.ipynb",
@@ -42,6 +43,7 @@ OWNER_ANALYSES = {
         "validate_row_counts.py",
         "validate_semantic_parity.py",
     },
+    "ojs-journal-metadata": {"enrich_openalex.py"},
     "scimago-openalex-coverage": {"coverage.py", "match_by_issn.py", "merge_sjr.py"},
 }
 
@@ -108,7 +110,9 @@ def test_all_exploratory_notebooks_have_named_owner_contracts() -> None:
 
 
 def test_notebook_launch_commands_include_shared_source_path() -> None:
-    for owner in OWNER_NOTEBOOKS:
+    for owner, notebooks in OWNER_NOTEBOOKS.items():
+        if not notebooks:
+            continue
         readme = (PROJECT_ROOT / "research" / owner / "README.md").read_text(
             encoding="utf-8"
         )

--- a/tests/test_ojs_journal_enrichment_contract.py
+++ b/tests/test_ojs_journal_enrichment_contract.py
@@ -68,6 +68,8 @@ def test_disagreement_analysis_is_separate_and_offline():
 
     assert "pkp-ojs-multisource-enriched.csv.gz" in disagreement
     assert "is_missing_value(left) || is_missing_value(right)" in disagreement
+    assert 'category = "unmapped_nonmissing"' in disagreement
+    assert "match(row_identity(sample_spec), row_identity(audit))" in disagreement
     assert "file.rename(temporary_path, path)" in disagreement
     assert "ojs_journal_disagreement_analysis" in disagreement
     assert "ojs_journal_disagreement_analysis" in render

--- a/tests/test_ojs_journal_enrichment_contract.py
+++ b/tests/test_ojs_journal_enrichment_contract.py
@@ -1,13 +1,16 @@
 from pathlib import Path
 
 
-ANALYSIS_DIR = (
-    Path(__file__).parents[1]
-    / "research"
-    / "ojs-journal-metadata"
-    / "analysis"
-)
+PROJECT_ROOT = Path(__file__).parents[1]
+ANALYSIS_DIR = PROJECT_ROOT / "research" / "ojs-journal-metadata" / "analysis"
 QMD_PATH = ANALYSIS_DIR / "ojs_journal_enrichment.qmd"
+DISAGREEMENT_OWNER_DIR = PROJECT_ROOT / "research" / "ojs-journal-metadata"
+DISAGREEMENT_ANALYSIS_DIR = DISAGREEMENT_OWNER_DIR / "analysis"
+DISAGREEMENT_QMD_PATH = (
+    DISAGREEMENT_ANALYSIS_DIR / "ojs_journal_disagreement_analysis.qmd"
+)
+FULL_RENDER_PATH = ANALYSIS_DIR / "render_full.sh"
+DISAGREEMENT_RENDER_PATH = DISAGREEMENT_ANALYSIS_DIR / "render_disagreement.sh"
 
 
 def test_full_pipeline_has_no_cross_language_conversion_layer():
@@ -18,13 +21,62 @@ def test_full_pipeline_has_no_cross_language_conversion_layer():
         assert fragment not in qmd
 
 
-def test_full_pipeline_declares_compressed_tabular_outputs():
+def test_enrichment_produces_one_wide_master():
     qmd = QMD_PATH.read_text()
+    render = FULL_RENDER_PATH.read_text()
 
+    assert "pkp-ojs-multisource-enriched.csv.gz" in qmd
+    assert "expand_candidate_fields" in qmd
+    assert "_candidates__json" in qmd
+    assert "length(match$candidates) > 1L" in qmd
+    assert "deduplicate = FALSE" in qmd
+    assert "seen_keys" not in qmd
+    assert 'prefix, "_candidate_"' not in qmd
     for filename in (
-        "pkp-ojs-multisource-enriched.csv.gz",
         "openalex-source-index.csv.gz",
         "crossref-journal-index.csv.gz",
-        "pkp-openalex-disagreement-audit.csv.gz",
+        "pkp-openalex-disagreement-audit.csv",
+        "pkp-openalex-disagreement-summary.csv",
     ):
-        assert filename in qmd
+        assert filename not in qmd
+        assert filename not in render
+
+
+def test_disagreement_analysis_is_separate_and_offline():
+    assert not (
+        PROJECT_ROOT / "research" / "ojs-journal-disagreement-analysis"
+    ).exists()
+    assert DISAGREEMENT_RENDER_PATH.stat().st_mode & 0o111
+    owner_readme = (DISAGREEMENT_OWNER_DIR / "README.md").read_text()
+    for heading in ("## Question", "## Referenced inputs", "## Run"):
+        assert heading in owner_readme
+    assert "ojs-journal-metadata" in (
+        PROJECT_ROOT / "research" / "README.md"
+    ).read_text()
+
+    enrichment = QMD_PATH.read_text()
+    disagreement = DISAGREEMENT_QMD_PATH.read_text()
+    render = DISAGREEMENT_RENDER_PATH.read_text()
+
+    for fragment in (
+        "identity_outcome",
+        "metadata_disagreement_summary",
+        "country_evidence_comparison",
+    ):
+        assert fragment not in enrichment
+        assert fragment in disagreement
+
+    assert "pkp-ojs-multisource-enriched.csv.gz" in disagreement
+    assert "is_missing_value(left) || is_missing_value(right)" in disagreement
+    assert "file.rename(temporary_path, path)" in disagreement
+    assert "ojs_journal_disagreement_analysis" in disagreement
+    assert "ojs_journal_disagreement_analysis" in render
+    assert 'test -d "$R_LIBS_USER"' in render
+    assert 'mkdir -p "$render_source_dir" "$R_LIBS_USER"' not in render
+    for fragment in (
+        "api.openalex.org",
+        "api.crossref.org",
+        "OPENALEX_API_KEY",
+        "CROSSREF_MAILTO",
+    ):
+        assert fragment not in disagreement


### PR DESCRIPTION
## Summary
- keep the full-cohort enrichment QMD focused on one validated wide master
- move the complete offline disagreement audit into a separate QMD under the same OJS metadata owner
- preserve title, ISSN, OJS, DOAJ, country, identity, source-status, and fixed ten-row review analyses
- ignore local RStudio state and remove the tracked .Rhistory

This is the clean delivery branch for the net changes that were pushed after PR #104 had already merged.

## Validation
- full offline disagreement render from the validated 98,273-row master
- 11 targeted tests passed
- shell syntax checks passed
- full suite: 29 passed, 1 unrelated baseline failure in tests/test_publication_compendium.py (reproduces on origin/main)
- Standards and Spec re-reviews: no remaining P0-P2 findings