### PR TITLE
Enforce strict OpenAlex candidate invariants

### DIFF
--- a/research/ojs-journal-metadata/analysis/enrich_openalex.py
+++ b/research/ojs-journal-metadata/analysis/enrich_openalex.py
@@ -956,6 +956,12 @@ def check_outputs(output_dir: Path) -> None:
                 continue
             country = enriched_row["country_consolidated"].strip()
             status = enriched_row["match_status"]
+            candidate_count = int(enriched_row["candidate_count"])
+            if status == "unique":
+                assert candidate_count == 1
+                assert enriched_row["candidate_types"] == "journal"
+            elif status == "ambiguous":
+                assert candidate_count > 1
             country_status_counts[country or MISSING_COUNTRY_GROUP][status] += 1
             valid_status_counts[status] += 1
             valid_routes.add(enriched_row["match_route"])


### PR DESCRIPTION
## Summary
- require unique matches to have exactly one journal candidate
- require ambiguous matches to have more than one candidate
- keep the fix at the final output-validation boundary

This is the clean delivery branch for the six lines that remained only on the closed issue #73 branch.

## Validation
- original full artifact passes the strengthened --check
- intentionally swapped unique/ambiguous artifact fails at the candidate-count assertion
- Python compile check passed
- Standards and Spec reviews found no P0-P2 issues